### PR TITLE
chore: add moca-storage-provider to stack

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -21,4 +21,7 @@ components:
   moca-cometbft:
     repo: mocachain/moca-cometbft
     ref: main
+  moca-storage-provider:
+    repo: mocachain/moca-storage-provider
+    ref: main
   # Add more repos as needed


### PR DESCRIPTION
Adds moca-storage-provider to stack.yaml for E2E integration testing.