### PR TITLE
chore: update known-good stack pointer

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@
 components:
   moca:
     repo: mocachain/moca
-    ref: main
+    ref: 12c9f554c9fba76766515102e01c5ceeec4379a7
   moca-storage-provider:
     repo: mocachain/moca-storage-provider
     ref: main


### PR DESCRIPTION
## Auto-generated rolling PR

Updates stack.yaml with latest tested component refs.
This PR is automatically force-pushed when source repos merge to main.

**Do not manually merge** — the advance-pointer workflow handles this on green CI.