### PR TITLE
chore: update known-good stack pointer

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@
 components:
   moca:
     repo: mocachain/moca
-    ref: 9c20c45660d87b428e97f6896cf075bcb39785b0
+    ref: a2388a50c530c8cc65edc8a6c41d88f2d2cacd22
   moca-storage-provider:
     repo: mocachain/moca-storage-provider
     ref: 512e6cf35fea9a18fa0cc21b55e13994a92c09ec


### PR DESCRIPTION
## Auto-generated rolling PR

Updates stack.yaml with latest tested component refs.
Automatically force-pushed when source repos merge to main.

**Do not manually merge** — advance-pointer workflow handles this on green CI.