### PR TITLE
test(storage): cover successor download after failover and exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Source repo merges to main
 | `test_cross_module` | Bank, Staking, Distribution — sequential txs across modules |
 | `test_storage_bucket` | Storage — bucket create/query/delete via `mocad`; if `moca-cmd` is available, full bucket CLI flow |
 | `test_storage_object` | Storage — full object CLI flow (`put`, `head`, `setTag`, `ls`, cleanup) when `moca-cmd` is available; else bucket-only `mocad` smoke |
-| `test_storage_object_failover` | Storage — graceful-exit the local primary SP, wait for successor takeover, and verify object reads remain available |
+| `test_storage_object_failover` | Storage — pause the local primary SP, manually run successor `swapIn/recover-vgf/completeSwapIn`, and verify object reads remain available |
 | `test_storage_object_seal` | Storage — poll `object get-progress` until sealed, then head/list |
 | `test_storage_group` | Storage — group lifecycle via `mocad`; if `moca-cmd` is available, full group CLI flow |
 | `test_storage_policy` | Storage — bucket/object/group policy CRUD via `moca-cmd` GRNs when available; else `mocad put-policy` |

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Source repo merges to main
 | `test_cross_module` | Bank, Staking, Distribution — sequential txs across modules |
 | `test_storage_bucket` | Storage — bucket create/query/delete via `mocad`; if `moca-cmd` is available, full bucket CLI flow |
 | `test_storage_object` | Storage — full object CLI flow (`put`, `head`, `setTag`, `ls`, cleanup) when `moca-cmd` is available; else bucket-only `mocad` smoke |
-| `test_storage_object_failover` | Storage — pause local primary SP, `object get` through secondary fallback, verify SHA-256 |
+| `test_storage_object_failover` | Storage — graceful-exit the local primary SP, wait for successor takeover, and verify object reads remain available |
 | `test_storage_object_seal` | Storage — poll `object get-progress` until sealed, then head/list |
 | `test_storage_group` | Storage — group lifecycle via `mocad`; if `moca-cmd` is available, full group CLI flow |
 | `test_storage_policy` | Storage — bucket/object/group policy CRUD via `moca-cmd` GRNs when available; else `mocad put-policy` |

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Source repo merges to main
 | `test_cross_module` | Bank, Staking, Distribution — sequential txs across modules |
 | `test_storage_bucket` | Storage — bucket create/query/delete via `mocad`; if `moca-cmd` is available, full bucket CLI flow |
 | `test_storage_object` | Storage — full object CLI flow (`put`, `head`, `setTag`, `ls`, cleanup) when `moca-cmd` is available; else bucket-only `mocad` smoke |
-| `test_storage_object_failover` | Storage — pause the local primary SP, manually run successor `swapIn/recover-vgf/completeSwapIn`, and verify object reads remain available |
+| `test_storage_object_failover` | Storage — force the local primary SP into exit, pause its endpoint, manually run successor `swapIn/recover-vgf/completeSwapIn`, and verify object reads remain available |
 | `test_storage_object_seal` | Storage — poll `object get-progress` until sealed, then head/list |
 | `test_storage_group` | Storage — group lifecycle via `mocad`; if `moca-cmd` is available, full group CLI flow |
 | `test_storage_policy` | Storage — bucket/object/group policy CRUD via `moca-cmd` GRNs when available; else `mocad put-policy` |

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Source repo merges to main
 | `test_cross_module` | Bank, Staking, Distribution — sequential txs across modules |
 | `test_storage_bucket` | Storage — bucket create/query/delete via `mocad`; if `moca-cmd` is available, full bucket CLI flow |
 | `test_storage_object` | Storage — full object CLI flow (`put`, `head`, `setTag`, `ls`, cleanup) when `moca-cmd` is available; else bucket-only `mocad` smoke |
+| `test_storage_object_failover` | Storage — pause local primary SP, `object get` through secondary fallback, verify SHA-256 |
 | `test_storage_object_seal` | Storage — poll `object get-progress` until sealed, then head/list |
 | `test_storage_group` | Storage — group lifecycle via `mocad`; if `moca-cmd` is available, full group CLI flow |
 | `test_storage_policy` | Storage — bucket/object/group policy CRUD via `moca-cmd` GRNs when available; else `mocad put-policy` |

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -6,7 +6,7 @@ environment: local
 chain:
   chain_id: moca_5151-1
   rpc: http://localhost:26657
-  grpc: localhost:9090
+  grpc: localhost:19090
   rest: http://localhost:1317
   evm_rpc: http://localhost:8545
   evm_ws: ws://localhost:8546

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -231,6 +231,68 @@ wait_for_object_sealed() {
   done
 }
 
+sha256_file() {
+  local path="${1:?path required}"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$path" | awk '{print $1}'
+    return 0
+  fi
+  shasum -a 256 "$path" | awk '{print $1}'
+}
+
+sha256_file_docker_aware() {
+  local path="${1:?path required}"
+  local target
+  if [ -r "$path" ]; then
+    sha256_file "$path"
+    return 0
+  fi
+
+  target="$(resolve_moca_cmd 2>/dev/null || true)"
+  if [[ "$target" == docker:* ]]; then
+    docker exec "${target#docker:}" sh -lc '
+      if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk "{print \$1}"
+      else
+        shasum -a 256 "$1" | awk "{print \$1}"
+      fi
+    ' sh "$path" 2>/dev/null
+    return $?
+  fi
+
+  return 1
+}
+
+remove_file_docker_aware() {
+  local path="${1:?path required}"
+  local target
+  rm -f "$path" >/dev/null 2>&1 || true
+
+  target="$(resolve_moca_cmd 2>/dev/null || true)"
+  if [[ "$target" == docker:* ]]; then
+    docker exec "${target#docker:}" rm -f "$path" >/dev/null 2>&1 || true
+    rm -f "$path" >/dev/null 2>&1 || true
+  fi
+}
+
+timed_object_get() {
+  local timeout_seconds="${1:?timeout seconds required}"
+  shift
+  local target
+
+  target="$(resolve_moca_cmd 2>/dev/null)" || return 127
+  if [[ "$target" == docker:* ]]; then
+    docker exec "${target#docker:}" sh -lc '
+      timeout="$1"
+      shift
+      exec timeout "$timeout" moca-cmd -p /root/.moca-cmd/password.txt "$@"
+    ' sh "$timeout_seconds" "$@" 2>/dev/null
+    return $?
+  fi
+
+  exec_moca_cmd_signed "$@"
+}
+
 # --- Assertion helpers ---
 assert_gt() {
   local actual="$1" expected="$2" msg="$3"

--- a/tests/test_sp_exit.sh
+++ b/tests/test_sp_exit.sh
@@ -124,6 +124,11 @@ if [ -z "$SP_ID" ] || [ "$SP_ID" = "null" ]; then
   echo "SKIP: cannot resolve on-chain SP ID for ${TARGET_SP}"
   exit 0
 fi
+TARGET_SP_ENDPOINT="$(echo "$SP_INFO" | jq -r '.storage_provider.endpoint // .storageProvider.endpoint // empty' 2>/dev/null || true)"
+if [ -z "$TARGET_SP_ENDPOINT" ] || [ "$TARGET_SP_ENDPOINT" = "null" ]; then
+  echo "SKIP: cannot resolve endpoint for target SP ${TARGET_SP}"
+  exit 0
+fi
 
 BUCKET_NAME="e2e-sp-exit-$(date +%s)-${RANDOM}"
 BUCKET_URL="moca://${BUCKET_NAME}"
@@ -133,9 +138,13 @@ SECONDARY_OBJECT_NAME="secondary_exit_obj.txt"
 HOST_TEST_FILE="$(create_test_file "/tmp/${OBJECT_NAME}" "sp exit object $(date)")"
 CONTAINER_TEST_FILE="/tmp/${OBJECT_NAME}"
 SECONDARY_OBJECT_REL=""
+DOWNLOAD_FILE="/tmp/${BUCKET_NAME}-downloaded.txt"
+TARGET_ONLY_DOWNLOAD_FILE="/tmp/${BUCKET_NAME}-from-exited-sp.txt"
 
 cleanup() {
   rm -f "$HOST_TEST_FILE"
+  remove_file_docker_aware "$DOWNLOAD_FILE"
+  remove_file_docker_aware "$TARGET_ONLY_DOWNLOAD_FILE"
   if [ -n "${SECONDARY_OBJECT_REL:-}" ]; then
     exec_moca_cmd object rm "$SECONDARY_OBJECT_REL" >/dev/null 2>&1 || true
   fi
@@ -403,6 +412,7 @@ PRIMARY_COUNT_BEFORE="$(gvg_stat_value "$SP_ID" primary_count)"
 SECONDARY_COUNT_BEFORE="$(gvg_stat_value "$SP_ID" secondary_count)"
 echo "  primary_count_before=${PRIMARY_COUNT_BEFORE}"
 echo "  secondary_count_before=${SECONDARY_COUNT_BEFORE}"
+SOURCE_SHA="$(sha256_file "$HOST_TEST_FILE")"
 if gvg_statistics_query_supported; then
   assert_gt "$SECONDARY_COUNT_BEFORE" "0" "target SP has secondary GVGs before exit"
 else
@@ -537,6 +547,37 @@ if [ -n "$SUCCESSOR_IDS" ]; then
 $SUCCESSOR_IDS
 EOF
   echo "  OK: successor SPs from query.sp.exit exist on chain"
+fi
+
+print_test_section "verify object downloads from successor after original SP exits"
+NEW_PRIMARY_SP_ENDPOINT="$(printf '%s\n' "$SP_JSON_AFTER" | jq -r --arg sid "$NEW_PRIMARY_SP_ID" '.sps[] | select((.id|tostring) == $sid) | .endpoint' 2>/dev/null | head -1)"
+if [ -z "$NEW_PRIMARY_SP_ENDPOINT" ] || [ "$NEW_PRIMARY_SP_ENDPOINT" = "null" ]; then
+  echo "FAIL: could not resolve endpoint for new primary SP ID ${NEW_PRIMARY_SP_ID}"
+  exit 1
+fi
+
+remove_file_docker_aware "$DOWNLOAD_FILE"
+download_out="$(timed_object_get 60 object get --spEndpoint "$NEW_PRIMARY_SP_ENDPOINT" "$OBJECT_REL" "$DOWNLOAD_FILE" || true)"
+if [ ! -f "$DOWNLOAD_FILE" ]; then
+  echo "$download_out"
+  echo "FAIL: object get from successor SP did not produce a downloaded file after exit"
+  exit 1
+fi
+DOWNLOAD_SHA="$(sha256_file_docker_aware "$DOWNLOAD_FILE" || true)"
+assert_eq "$DOWNLOAD_SHA" "$SOURCE_SHA" "downloaded object matches original sha256 after successor takeover"
+echo "  OK: object downloaded successfully from successor endpoint ${NEW_PRIMARY_SP_ENDPOINT}"
+
+if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^${TARGET_SP}$"; then
+  remove_file_docker_aware "$TARGET_ONLY_DOWNLOAD_FILE"
+  if target_get_out="$(timed_object_get 20 object get --spEndpoint "$TARGET_SP_ENDPOINT" "$OBJECT_REL" "$TARGET_ONLY_DOWNLOAD_FILE")"; then
+    echo "$target_get_out"
+    echo "FAIL: object get unexpectedly succeeded via exited SP endpoint ${TARGET_SP_ENDPOINT}"
+    exit 1
+  fi
+  remove_file_docker_aware "$TARGET_ONLY_DOWNLOAD_FILE"
+  echo "  OK: exited SP endpoint no longer serves object downloads"
+else
+  echo "  INFO: target SP container ${TARGET_SP} is still running locally; chain removal is used as the exit-offline signal"
 fi
 
 trap - EXIT

--- a/tests/test_storage_object_failover.sh
+++ b/tests/test_storage_object_failover.sh
@@ -118,7 +118,7 @@ timed_object_get() {
 exec_validator_mocad() {
   local validator_index="${1:?validator index required}"
   shift
-  docker exec "validator-${validator_index}" mocad "$@" --home /root/.mocad 2>/dev/null
+  docker exec "validator-${validator_index}" mocad "$@" --home /root/.mocad
 }
 
 current_proposal_count() {
@@ -223,7 +223,7 @@ EOF
 
   printf '%s\n' "$proposal_json" | docker exec -i validator-0 sh -lc "cat > ${tmpfile}"
   submit_out="$(exec_validator_mocad 0 tx gov submit-proposal "${tmpfile}" \
-    --from validator0 \
+    --from validator-0 \
     --keyring-backend test \
     --chain-id "$CHAIN_ID" \
     --node tcp://localhost:26657 \
@@ -253,7 +253,7 @@ EOF
 
   for validator_name in $(docker ps --format '{{.Names}}' 2>/dev/null | grep -E '^validator-[0-9]+$' | sort -V); do
     vote_out="$(docker exec "$validator_name" mocad tx gov vote "$proposal_id" yes \
-      --from "validator${validator_name#validator-}" \
+      --from "$validator_name" \
       --keyring-backend test \
       --chain-id "$CHAIN_ID" \
       --node tcp://localhost:26657 \

--- a/tests/test_storage_object_failover.sh
+++ b/tests/test_storage_object_failover.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# E2E: successor SP takes over a primary SP and keeps object reads available.
+# E2E: manual object failover after the primary SP becomes unavailable.
 set -euo pipefail
 
 ENV="${1:-local}"
@@ -19,6 +19,7 @@ if ! resolve_moca_cmd >/dev/null 2>&1; then
   echo "SKIP: moca-cmd required for object get failover"
   exit 0
 fi
+MOCA_CMD_TARGET="$(resolve_moca_cmd 2>/dev/null || true)"
 
 SP_CHECK="$(exec_mocad query sp storage-providers --node "$TM_RPC" --output json 2>/dev/null || echo "")"
 NUM_SPS="$(echo "$SP_CHECK" | jq -r '.sps | length // 0' 2>/dev/null || echo "0")"
@@ -42,6 +43,12 @@ if [ -z "$PRIMARY_SP_ID" ] || [ "$PRIMARY_SP_ID" = "null" ]; then
   exit 0
 fi
 
+PRIMARY_SP_ENDPOINT="$(printf '%s\n' "$SP_CHECK" | jq -r --arg primary_operator "$PRIMARY_SP" '.sps[] | select(.operator_address == $primary_operator) | .endpoint' 2>/dev/null | head -1)"
+if [ -z "$PRIMARY_SP_ENDPOINT" ] || [ "$PRIMARY_SP_ENDPOINT" = "null" ]; then
+  echo "SKIP: cannot resolve endpoint for local primary SP container ${PRIMARY_SP_CONTAINER}"
+  exit 0
+fi
+
 PRIMARY_STATUS="$(get_sp_status_by_operator "$PRIMARY_SP")"
 if [ "$PRIMARY_STATUS" != "STATUS_IN_SERVICE" ] && [ "$PRIMARY_STATUS" != "0" ]; then
   echo "SKIP: local primary SP ${PRIMARY_SP_CONTAINER} is not IN_SERVICE (status=${PRIMARY_STATUS:-unknown})"
@@ -57,11 +64,86 @@ sha256_file() {
   shasum -a 256 "$path" | awk '{print $1}'
 }
 
+sha256_file_docker_aware() {
+  local path="${1:?path required}"
+  if [ -r "$path" ]; then
+    sha256_file "$path"
+    return 0
+  fi
+  if [[ "$MOCA_CMD_TARGET" == docker:* ]]; then
+    docker exec "${MOCA_CMD_TARGET#docker:}" sh -lc '
+      if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk "{print \$1}"
+      else
+        shasum -a 256 "$1" | awk "{print \$1}"
+      fi
+    ' sh "$path" 2>/dev/null
+    return $?
+  fi
+  return 1
+}
+
+remove_file_docker_aware() {
+  local path="${1:?path required}"
+  rm -f "$path" >/dev/null 2>&1 || true
+  if [ -e "$path" ] && [[ "$MOCA_CMD_TARGET" == docker:* ]]; then
+    docker exec "${MOCA_CMD_TARGET#docker:}" rm -f "$path" >/dev/null 2>&1 || true
+    rm -f "$path" >/dev/null 2>&1 || true
+  fi
+}
+
 gvg_primary_sp_id_by_family() {
   local family_id="${1:?family id required}"
   exec_mocad query virtualgroup global-virtual-group-by-family-id "$family_id" \
     --node "$TM_RPC" --output json 2>/dev/null \
     | jq -r '.global_virtual_groups[0].primary_sp_id // empty' 2>/dev/null || true
+}
+
+gvg_json_by_family() {
+  local family_id="${1:?family id required}"
+  exec_mocad query virtualgroup global-virtual-group-by-family-id "$family_id" \
+    --node "$TM_RPC" --output json 2>/dev/null || echo '{}'
+}
+
+gvg_secondary_sp_ids_by_family() {
+  local family_id="${1:?family id required}"
+  gvg_json_by_family "$family_id" \
+    | jq -r '.global_virtual_groups[0].secondary_sp_ids[]? // empty' 2>/dev/null || true
+}
+
+gvg_count_by_family() {
+  local family_id="${1:?family id required}"
+  exec_mocad query virtualgroup global-virtual-group-family "$family_id" \
+    --node "$TM_RPC" --output json 2>/dev/null \
+    | jq -r '(.global_virtual_group_family.global_virtual_group_ids // []) | length' 2>/dev/null || echo "0"
+}
+
+sp_moniker_by_id() {
+  local sp_id="${1:?sp id required}"
+  printf '%s\n' "$SP_CHECK" | jq -r --argjson sid "$sp_id" '.sps[] | select(.id == $sid) | (.description.moniker // empty)' 2>/dev/null | head -1
+}
+
+sp_operator_by_id() {
+  local sp_id="${1:?sp id required}"
+  printf '%s\n' "$SP_CHECK" | jq -r --argjson sid "$sp_id" '.sps[] | select(.id == $sid) | .operator_address' 2>/dev/null | head -1
+}
+
+sp_container_by_id() {
+  local sp_id="${1:?sp id required}"
+  local moniker
+
+  moniker="$(sp_moniker_by_id "$sp_id")"
+  if [[ "$moniker" =~ ^sp-[0-9]+$ ]]; then
+    printf '%s\n' "$moniker"
+    return 0
+  fi
+
+  if [ "$sp_id" -gt 0 ] 2>/dev/null; then
+    printf 'sp-%s\n' "$((sp_id - 1))"
+    return 0
+  fi
+
+  return 1
 }
 
 wait_for_gvg_primary_sp_change() {
@@ -86,36 +168,29 @@ wait_for_gvg_primary_sp_change() {
   done
 }
 
-wait_for_sp_removed_from_list() {
-  local operator="${1:?operator required}"
-  local timeout="${2:-180}"
-  local deadline now sp_json
-
-  deadline=$(( $(date +%s) + timeout ))
-  while :; do
-    sp_json="$(exec_mocad query sp storage-providers --node "$TM_RPC" --output json 2>/dev/null || echo '{}')"
-    if ! printf '%s\n' "$sp_json" | jq -e --arg op "$operator" '.sps[] | select(.operator_address == $op)' >/dev/null 2>&1; then
-      return 0
-    fi
-    now=$(date +%s)
-    if [ "$now" -ge "$deadline" ]; then
-      echo "  wait_for_sp_removed_from_list: timeout after ${timeout}s; operator still present: ${operator}" >&2
-      return 1
-    fi
-    sleep 3
-  done
+run_successor_swap_cmd() {
+  local container="${1:?container required}"
+  shift
+  docker exec "$container" moca-sp "$@" 2>&1 || true
 }
 
+PRIMARY_PAUSED=0
 BUCKET_NAME="$(generate_bucket_name "e2e-obj-failover")"
 BUCKET_URL="moca://${BUCKET_NAME}"
 OBJECT_NAME="failover-object.txt"
 OBJECT_URL="${BUCKET_URL}/${OBJECT_NAME}"
 SOURCE_FILE="$(create_test_file "/tmp/${BUCKET_NAME}-${OBJECT_NAME}" "storage failover $(date)")"
 DOWNLOAD_FILE="/tmp/${BUCKET_NAME}-${OBJECT_NAME}.downloaded"
+PRIMARY_ONLY_DOWNLOAD_FILE="/tmp/${BUCKET_NAME}-${OBJECT_NAME}.primary-only"
 
 cleanup() {
+  if [ "$PRIMARY_PAUSED" = "1" ]; then
+    docker unpause "$PRIMARY_SP_CONTAINER" >/dev/null 2>&1 || true
+    PRIMARY_PAUSED=0
+  fi
   rm -f "$SOURCE_FILE" >/dev/null 2>&1 || true
-  rm -f "$DOWNLOAD_FILE" >/dev/null 2>&1 || true
+  remove_file_docker_aware "$DOWNLOAD_FILE"
+  remove_file_docker_aware "$PRIMARY_ONLY_DOWNLOAD_FILE"
   exec_moca_cmd_signed object rm "$OBJECT_URL" >/dev/null 2>&1 || true
   exec_moca_cmd_signed bucket rm "$BUCKET_URL" >/dev/null 2>&1 || true
 }
@@ -138,7 +213,7 @@ if ! echo "$put_out" | grep -qiE "object.*created|created on chain|upload"; then
 fi
 print_success "object put completed (SEALED)"
 
-print_test_section "Step 3: record pre-exit primary ownership"
+print_test_section "Step 3: record pre-failover family ownership"
 before_bucket_head="$(exec_moca_cmd bucket head "$BUCKET_URL" 2>&1 || true)"
 if ! echo "$before_bucket_head" | grep -q "bucket_name:\"$BUCKET_NAME\""; then
   echo "$before_bucket_head"
@@ -150,85 +225,105 @@ BUCKET_FAMILY_ID="$(printf '%s\n' "$before_bucket_head" | awk -F': ' '/^virtual_
 BEFORE_PRIMARY_SP_ID="$(printf '%s\n' "$before_bucket_head" | awk -F': ' '/^primary SP ID:/ {print $2; exit}')"
 if [ -z "$BUCKET_FAMILY_ID" ] || [ -z "$BEFORE_PRIMARY_SP_ID" ]; then
   echo "$before_bucket_head"
-  echo "FAIL: could not resolve bucket family ID / primary SP ID before exit"
+  echo "FAIL: could not resolve bucket family ID / primary SP ID before failover"
   exit 1
 fi
-assert_eq "$BEFORE_PRIMARY_SP_ID" "$PRIMARY_SP_ID" "bucket primary SP ID matches target SP before exit"
+assert_eq "$BEFORE_PRIMARY_SP_ID" "$PRIMARY_SP_ID" "bucket primary SP ID matches target SP before failover"
 
-print_test_section "Step 4: send sp.exit from ${PRIMARY_SP_CONTAINER}"
-sp_exit_out="$(exec_sp_cmd "$PRIMARY_SP_CONTAINER" -c /root/.moca-sp/config.toml sp.exit --operatorAddress "$PRIMARY_SP" 2>&1 || true)"
-if ! echo "$sp_exit_out" | grep -q "send sp exit txn successfully"; then
-  echo "$sp_exit_out"
-  echo "FAIL: moca-sp sp.exit did not return success"
-  exit 1
-fi
-echo "$sp_exit_out"
+GVG_COUNT="$(gvg_count_by_family "$BUCKET_FAMILY_ID")"
+SUCCESSOR_SP_ID=""
+while IFS= read -r candidate_sp_id; do
+  [ -n "$candidate_sp_id" ] || continue
+  SUCCESSOR_CONTAINER="$(sp_container_by_id "$candidate_sp_id" || true)"
+  [ -n "$SUCCESSOR_CONTAINER" ] || continue
+  if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^${SUCCESSOR_CONTAINER}$"; then
+    SUCCESSOR_SP_ID="$candidate_sp_id"
+    break
+  fi
+done <<EOF
+$(gvg_secondary_sp_ids_by_family "$BUCKET_FAMILY_ID")
+EOF
 
-print_test_section "Step 5: wait for chain status to become graceful exiting"
-if ! wait_for_sp_status "$PRIMARY_SP" "STATUS_GRACEFUL_EXITING" 180; then
-  echo "FAIL: primary SP never entered STATUS_GRACEFUL_EXITING"
+if [ -z "$SUCCESSOR_SP_ID" ]; then
+  echo "FAIL: could not find a running successor SP in family ${BUCKET_FAMILY_ID}"
   exit 1
 fi
-print_success "chain status is STATUS_GRACEFUL_EXITING"
 
-print_test_section "Step 6: query successor takeover plan"
-query_out="$(exec_sp_cmd "$PRIMARY_SP_CONTAINER" query.sp.exit -c /root/.moca-sp/config.toml --endpoint localhost:9333 2>&1 || true)"
-echo "$query_out"
-if echo "$query_out" | grep -q "spExitScheduler not exit"; then
-  echo "FAIL: sp exit scheduler was not started"
+SUCCESSOR_CONTAINER="$(sp_container_by_id "$SUCCESSOR_SP_ID")"
+SUCCESSOR_OPERATOR="$(sp_operator_by_id "$SUCCESSOR_SP_ID")"
+if [ -z "$SUCCESSOR_OPERATOR" ] || [ "$SUCCESSOR_OPERATOR" = "null" ]; then
+  echo "FAIL: could not resolve successor operator for SP ID ${SUCCESSOR_SP_ID}"
   exit 1
 fi
-if ! echo "$query_out" | jq -e '.self_sp_id >= 0' >/dev/null 2>&1; then
-  echo "FAIL: query.sp.exit did not return the expected JSON payload"
-  exit 1
-fi
-SUCCESSOR_IDS="$(echo "$query_out" | jq -r '[.swap_out_dest[]?.successor_sp_id] | unique | .[]' 2>/dev/null || true)"
+print_success "selected successor ${SUCCESSOR_CONTAINER} (sp_id=${SUCCESSOR_SP_ID}) for manual failover"
 
-print_test_section "Step 7: wait for successor SP to become the new primary"
+print_test_section "Step 4: pause primary SP container"
+docker pause "$PRIMARY_SP_CONTAINER" >/dev/null
+PRIMARY_PAUSED=1
+sleep 3
+print_success "primary container paused"
+
+print_test_section "Step 5: verify forced primary endpoint is unavailable"
+remove_file_docker_aware "$PRIMARY_ONLY_DOWNLOAD_FILE"
+if primary_get_out="$(exec_moca_cmd_signed object get --spEndpoint "$PRIMARY_SP_ENDPOINT" "$OBJECT_URL" "$PRIMARY_ONLY_DOWNLOAD_FILE")"; then
+  echo "$primary_get_out"
+  echo "FAIL: object get unexpectedly succeeded when forced to use paused primary endpoint ${PRIMARY_SP_ENDPOINT}"
+  exit 1
+fi
+remove_file_docker_aware "$PRIMARY_ONLY_DOWNLOAD_FILE"
+print_success "forced primary endpoint download failed as expected"
+
+print_test_section "Step 6: manually reserve swap-in on successor"
+swapin_out="$(run_successor_swap_cmd "$SUCCESSOR_CONTAINER" swapIn --config /root/.moca-sp/config.toml --vgf "$BUCKET_FAMILY_ID" --gvgId 0 --targetSP "$PRIMARY_SP_ID")"
+echo "$swapin_out"
+if ! printf '%s\n' "$swapin_out" | grep -qiE 'tx hash|txhash|broadcast|success'; then
+  echo "FAIL: swapIn did not report a successful submission"
+  exit 1
+fi
+
+if [ "$GVG_COUNT" != "0" ]; then
+  print_test_section "Step 7: recover family on successor"
+  recover_out="$(run_successor_swap_cmd "$SUCCESSOR_CONTAINER" recover-vgf --config /root/.moca-sp/config.toml --vgf "$BUCKET_FAMILY_ID")"
+  echo "$recover_out"
+  if printf '%s\n' "$recover_out" | grep -qiE 'panic|fatal|error'; then
+    echo "FAIL: recover-vgf reported an error"
+    exit 1
+  fi
+else
+  print_test_section "Step 7: skip recover-vgf for empty family"
+  print_success "family ${BUCKET_FAMILY_ID} has no GVGs; recover-vgf not needed"
+fi
+
+print_test_section "Step 8: complete swap-in on successor"
+complete_swapin_out="$(run_successor_swap_cmd "$SUCCESSOR_CONTAINER" completeSwapIn --config /root/.moca-sp/config.toml --vgf "$BUCKET_FAMILY_ID" --gvgId 0)"
+echo "$complete_swapin_out"
+if ! printf '%s\n' "$complete_swapin_out" | grep -qiE 'tx hash|txhash|broadcast|success'; then
+  echo "FAIL: completeSwapIn did not report a successful submission"
+  exit 1
+fi
+
+print_test_section "Step 9: wait for family primary to switch to successor"
 NEW_PRIMARY_SP_ID="$(wait_for_gvg_primary_sp_change "$BUCKET_FAMILY_ID" "$BEFORE_PRIMARY_SP_ID" 180)"
-assert_ne "$NEW_PRIMARY_SP_ID" "$BEFORE_PRIMARY_SP_ID" "GVG primary SP changed after graceful exit"
-if [ -n "$SUCCESSOR_IDS" ] && ! printf '%s\n' "$SUCCESSOR_IDS" | grep -qx "$NEW_PRIMARY_SP_ID"; then
-  echo "  successor_sp_ids from query.sp.exit:"
-  printf '%s\n' "$SUCCESSOR_IDS" | sed 's/^/    - /'
-  echo "FAIL: bucket migrated to unexpected primary SP ID ${NEW_PRIMARY_SP_ID}"
-  exit 1
-fi
-print_success "bucket primary moved from ${BEFORE_PRIMARY_SP_ID} to successor ${NEW_PRIMARY_SP_ID}"
+assert_eq "$NEW_PRIMARY_SP_ID" "$SUCCESSOR_SP_ID" "family primary switched to the selected successor SP"
 
-print_test_section "Step 8: verify object get succeeds after successor takeover"
-rm -f "$DOWNLOAD_FILE" >/dev/null 2>&1 || true
+print_test_section "Step 10: verify object get succeeds after manual failover"
+remove_file_docker_aware "$DOWNLOAD_FILE"
 get_out="$(exec_moca_cmd_signed object get "$OBJECT_URL" "$DOWNLOAD_FILE" || true)"
 if [ ! -f "$DOWNLOAD_FILE" ]; then
   echo "$get_out"
-  echo "FAIL: object get did not succeed after successor takeover"
+  echo "FAIL: object get did not produce a downloaded file after manual failover"
   exit 1
 fi
 
 SOURCE_SHA="$(sha256_file "$SOURCE_FILE")"
-DOWNLOAD_SHA="$(sha256_file "$DOWNLOAD_FILE")"
+DOWNLOAD_SHA="$(sha256_file_docker_aware "$DOWNLOAD_FILE" || true)"
 assert_eq "$DOWNLOAD_SHA" "$SOURCE_SHA" "downloaded object matches original sha256"
 
-print_test_section "Step 9: complete final primary SP exit"
-if wait_for_sp_removed_from_list "$PRIMARY_SP" 90; then
-  print_success "primary SP completed final exit automatically"
-else
-  complete_out="$(exec_sp_cmd "$PRIMARY_SP_CONTAINER" -c /root/.moca-sp/config.toml sp.complete.exit --operatorAddress "$PRIMARY_SP" 2>&1 || true)"
-  echo "$complete_out"
-  if ! echo "$complete_out" | grep -q "send complete sp exit txn successfully"; then
-    if ! wait_for_sp_removed_from_list "$PRIMARY_SP" 30; then
-      echo "FAIL: moca-sp sp.complete.exit did not return success"
-      exit 1
-    fi
-    print_success "primary SP completed final exit automatically while sp.complete.exit was racing"
-  else
-    if ! wait_for_sp_removed_from_list "$PRIMARY_SP" 180; then
-      echo "FAIL: primary SP still exists in chain SP list after complete exit"
-      exit 1
-    fi
-    print_success "primary SP removed from chain SP list after sp.complete.exit"
-  fi
-fi
+print_test_section "Step 11: resume original primary container"
+docker unpause "$PRIMARY_SP_CONTAINER" >/dev/null
+PRIMARY_PAUSED=0
+print_success "primary container resumed"
 
 trap - EXIT
 cleanup
-echo "PASS: storage object failover successor takeover test completed"
+echo "PASS: storage object manual failover test completed"

--- a/tests/test_storage_object_failover.sh
+++ b/tests/test_storage_object_failover.sh
@@ -19,7 +19,6 @@ if ! resolve_moca_cmd >/dev/null 2>&1; then
   echo "SKIP: moca-cmd required for object get failover"
   exit 0
 fi
-MOCA_CMD_TARGET="$(resolve_moca_cmd 2>/dev/null || true)"
 
 SP_CHECK="$(exec_mocad query sp storage-providers --node "$TM_RPC" --output json 2>/dev/null || echo "")"
 NUM_SPS="$(echo "$SP_CHECK" | jq -r '.sps | length // 0' 2>/dev/null || echo "0")"
@@ -60,60 +59,6 @@ if [ "$PRIMARY_STATUS" != "STATUS_IN_SERVICE" ] && [ "$PRIMARY_STATUS" != "0" ];
   echo "SKIP: local primary SP ${PRIMARY_SP_CONTAINER} is not IN_SERVICE (status=${PRIMARY_STATUS:-unknown})"
   exit 0
 fi
-
-sha256_file() {
-  local path="${1:?path required}"
-  if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "$path" | awk '{print $1}'
-    return 0
-  fi
-  shasum -a 256 "$path" | awk '{print $1}'
-}
-
-sha256_file_docker_aware() {
-  local path="${1:?path required}"
-  if [ -r "$path" ]; then
-    sha256_file "$path"
-    return 0
-  fi
-  if [[ "$MOCA_CMD_TARGET" == docker:* ]]; then
-    docker exec "${MOCA_CMD_TARGET#docker:}" sh -lc '
-      if command -v sha256sum >/dev/null 2>&1; then
-        sha256sum "$1" | awk "{print \$1}"
-      else
-        shasum -a 256 "$1" | awk "{print \$1}"
-      fi
-    ' sh "$path" 2>/dev/null
-    return $?
-  fi
-  return 1
-}
-
-remove_file_docker_aware() {
-  local path="${1:?path required}"
-  rm -f "$path" >/dev/null 2>&1 || true
-  if [ -e "$path" ] && [[ "$MOCA_CMD_TARGET" == docker:* ]]; then
-    docker exec "${MOCA_CMD_TARGET#docker:}" rm -f "$path" >/dev/null 2>&1 || true
-    rm -f "$path" >/dev/null 2>&1 || true
-  fi
-}
-
-timed_object_get() {
-  local timeout_seconds="${1:?timeout seconds required}"
-  shift
-
-  if [[ "$MOCA_CMD_TARGET" == docker:* ]]; then
-    local container="${MOCA_CMD_TARGET#docker:}"
-    docker exec "$container" sh -lc '
-      timeout="$1"
-      shift
-      exec timeout "$timeout" moca-cmd -p /root/.moca-cmd/password.txt "$@"
-    ' sh "$timeout_seconds" "$@" 2>/dev/null
-    return $?
-  fi
-
-  exec_moca_cmd_signed "$@"
-}
 
 exec_validator_mocad() {
   local validator_index="${1:?validator index required}"

--- a/tests/test_storage_object_failover.sh
+++ b/tests/test_storage_object_failover.sh
@@ -19,6 +19,7 @@ if ! resolve_moca_cmd >/dev/null 2>&1; then
   echo "SKIP: moca-cmd required for object get failover"
   exit 0
 fi
+MOCA_CMD_TARGET="$(resolve_moca_cmd 2>/dev/null || true)"
 
 SP_CHECK="$(exec_mocad query sp storage-providers --node "$TM_RPC" --output json 2>/dev/null || echo "")"
 NUM_SPS="$(echo "$SP_CHECK" | jq -r '.sps | length // 0' 2>/dev/null || echo "0")"
@@ -44,6 +45,34 @@ sha256_file() {
   shasum -a 256 "$path" | awk '{print $1}'
 }
 
+sha256_file_docker_aware() {
+  local path="${1:?path required}"
+  if [ -r "$path" ]; then
+    sha256_file "$path"
+    return 0
+  fi
+  if [[ "$MOCA_CMD_TARGET" == docker:* ]]; then
+    docker exec "${MOCA_CMD_TARGET#docker:}" sh -lc '
+      if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk "{print \$1}"
+      else
+        shasum -a 256 "$1" | awk "{print \$1}"
+      fi
+    ' sh "$path" 2>/dev/null
+    return $?
+  fi
+  return 1
+}
+
+remove_file_docker_aware() {
+  local path="${1:?path required}"
+  rm -f "$path" >/dev/null 2>&1 || true
+  if [ -e "$path" ] && [[ "$MOCA_CMD_TARGET" == docker:* ]]; then
+    docker exec "${MOCA_CMD_TARGET#docker:}" rm -f "$path" >/dev/null 2>&1 || true
+    rm -f "$path" >/dev/null 2>&1 || true
+  fi
+}
+
 PRIMARY_PAUSED=0
 BUCKET_NAME="$(generate_bucket_name "e2e-obj-failover")"
 BUCKET_URL="moca://${BUCKET_NAME}"
@@ -57,7 +86,8 @@ cleanup() {
     docker unpause "$PRIMARY_SP_CONTAINER" >/dev/null 2>&1 || true
     PRIMARY_PAUSED=0
   fi
-  rm -f "$SOURCE_FILE" "$DOWNLOAD_FILE"
+  rm -f "$SOURCE_FILE" >/dev/null 2>&1 || true
+  remove_file_docker_aware "$DOWNLOAD_FILE"
   exec_moca_cmd_signed bucket rm "$BUCKET_URL" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
@@ -94,7 +124,7 @@ if [ ! -f "$DOWNLOAD_FILE" ]; then
 fi
 
 SOURCE_SHA="$(sha256_file "$SOURCE_FILE")"
-DOWNLOAD_SHA="$(sha256_file "$DOWNLOAD_FILE")"
+DOWNLOAD_SHA="$(sha256_file_docker_aware "$DOWNLOAD_FILE" || true)"
 assert_eq "$DOWNLOAD_SHA" "$SOURCE_SHA" "downloaded object matches original sha256"
 
 print_test_section "Step 5: unpause primary SP container"

--- a/tests/test_storage_object_failover.sh
+++ b/tests/test_storage_object_failover.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# E2E: object read failover when the primary SP is unreachable.
+set -euo pipefail
+
+ENV="${1:-local}"
+_CONFIG_FILE="${2:-config/local.yaml}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+if [ "$ENV" != "local" ]; then
+  echo "SKIP: storage object failover test is local-only"
+  exit 0
+fi
+
+require_write_enabled "storage object failover test"
+
+if ! resolve_moca_cmd >/dev/null 2>&1; then
+  echo "SKIP: moca-cmd required for object get failover"
+  exit 0
+fi
+
+SP_CHECK="$(exec_mocad query sp storage-providers --node "$TM_RPC" --output json 2>/dev/null || echo "")"
+NUM_SPS="$(echo "$SP_CHECK" | jq -r '.sps | length // 0' 2>/dev/null || echo "0")"
+NUM_SPS="${NUM_SPS:-0}"
+if [ "$NUM_SPS" -lt 3 ]; then
+  echo "SKIP: object failover needs primary + 2 secondaries (have ${NUM_SPS} SPs)"
+  exit 0
+fi
+
+PRIMARY_SP_CONTAINER="sp-0"
+PRIMARY_SP="$(printf '%s\n' "$SP_CHECK" | jq -r '.sps[] | select((.status == "STATUS_IN_SERVICE" or .status == 0 or .status == "0") and (.endpoint | tostring | test(":9033$"))) | .operator_address' 2>/dev/null | head -1)"
+if [ -z "$PRIMARY_SP" ] || [ "$PRIMARY_SP" = "null" ]; then
+  echo "SKIP: cannot resolve operator for local primary SP container ${PRIMARY_SP_CONTAINER}"
+  exit 0
+fi
+
+sha256_file() {
+  local path="${1:?path required}"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$path" | awk '{print $1}'
+    return 0
+  fi
+  shasum -a 256 "$path" | awk '{print $1}'
+}
+
+PRIMARY_PAUSED=0
+BUCKET_NAME="$(generate_bucket_name "e2e-obj-failover")"
+BUCKET_URL="moca://${BUCKET_NAME}"
+OBJECT_NAME="failover-object.txt"
+OBJECT_URL="${BUCKET_URL}/${OBJECT_NAME}"
+SOURCE_FILE="$(create_test_file "/tmp/${BUCKET_NAME}-${OBJECT_NAME}" "storage failover $(date)")"
+DOWNLOAD_FILE="/tmp/${BUCKET_NAME}-${OBJECT_NAME}.downloaded"
+
+cleanup() {
+  if [ "$PRIMARY_PAUSED" = "1" ]; then
+    docker unpause "$PRIMARY_SP_CONTAINER" >/dev/null 2>&1 || true
+    PRIMARY_PAUSED=0
+  fi
+  rm -f "$SOURCE_FILE" "$DOWNLOAD_FILE"
+  exec_moca_cmd_signed bucket rm "$BUCKET_URL" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+print_test_section "Step 1: create bucket on ${PRIMARY_SP_CONTAINER}"
+bucket_out="$(moca_cmd_tx bucket create --primarySP "$PRIMARY_SP" "$BUCKET_URL" || true)"
+if ! echo "$bucket_out" | grep -q "make_bucket:\|$BUCKET_NAME"; then
+  echo "$bucket_out"
+  echo "FAIL: bucket create did not succeed"
+  exit 1
+fi
+
+print_test_section "Step 2: put object and wait for OBJECT_STATUS_SEALED"
+put_out="$(exec_moca_cmd_signed object put --contentType "application/octet-stream" "$SOURCE_FILE" "$OBJECT_URL" || true)"
+if ! echo "$put_out" | grep -qiE "object.*created|created on chain|upload"; then
+  echo "$put_out"
+  echo "FAIL: object put did not reach uploaded/sealed state"
+  exit 1
+fi
+print_success "object put completed (SEALED)"
+
+print_test_section "Step 3: pause primary SP container"
+docker pause "$PRIMARY_SP_CONTAINER" >/dev/null
+PRIMARY_PAUSED=1
+sleep 3
+print_success "primary container paused"
+
+print_test_section "Step 4: get object through secondary failover"
+get_out="$(exec_moca_cmd_signed object get "$OBJECT_URL" "$DOWNLOAD_FILE" || true)"
+if [ ! -f "$DOWNLOAD_FILE" ]; then
+  echo "$get_out"
+  echo "FAIL: object get did not produce a downloaded file while primary was paused"
+  exit 1
+fi
+
+SOURCE_SHA="$(sha256_file "$SOURCE_FILE")"
+DOWNLOAD_SHA="$(sha256_file "$DOWNLOAD_FILE")"
+assert_eq "$DOWNLOAD_SHA" "$SOURCE_SHA" "downloaded object matches original sha256"
+
+print_test_section "Step 5: unpause primary SP container"
+docker unpause "$PRIMARY_SP_CONTAINER" >/dev/null
+PRIMARY_PAUSED=0
+print_success "primary container resumed"
+
+trap - EXIT
+cleanup
+echo "PASS: storage object failover test completed"

--- a/tests/test_storage_object_failover.sh
+++ b/tests/test_storage_object_failover.sh
@@ -349,6 +349,57 @@ run_successor_swap_cmd() {
   docker exec "$container" moca-sp "$@" 2>&1 || true
 }
 
+extract_recover_process_json() {
+  printf '%s\n' "${1:-}" | awk '/^\[/{line=$0} END{print line}'
+}
+
+wait_for_successor_recover_complete() {
+  local container="${1:?container required}"
+  local vgf_id="${2:?vgf id required}"
+  local timeout="${3:-300}"
+  local deadline now query_out recover_json recover_summary
+
+  deadline=$(( $(date +%s) + timeout ))
+  while :; do
+    query_out="$(run_successor_swap_cmd "$container" query-recover-p --config /root/.moca-sp/config.toml --vgf "$vgf_id" --gvgId 0)"
+    recover_json="$(extract_recover_process_json "$query_out")"
+
+    if [ -n "$recover_json" ] && [ "$recover_json" != "[]" ]; then
+      if printf '%s\n' "$recover_json" | jq -e '
+        length > 0 and
+        all(.[]; .status == "Successful" and (.failed_object_total_count // 0) == 0)
+      ' >/dev/null 2>&1; then
+        printf '%s\n' "$recover_json"
+        return 0
+      fi
+
+      recover_summary="$(printf '%s\n' "$recover_json" | jq -c '
+        [.[] | {
+          gvg_id: .virtual_group_id,
+          status: .status,
+          failed_object_total_count: (.failed_object_total_count // 0),
+          object_count: (.object_count // 0)
+        }]
+      ' 2>/dev/null || true)"
+      if [ -n "$recover_summary" ]; then
+        echo "  recover progress: ${recover_summary}"
+      else
+        echo "$query_out"
+      fi
+    else
+      echo "$query_out"
+    fi
+
+    now=$(date +%s)
+    if [ "$now" -ge "$deadline" ]; then
+      echo "  wait_for_successor_recover_complete: timeout after ${timeout}s" >&2
+      [ -n "$recover_json" ] && printf '%s\n' "$recover_json" >&2
+      return 1
+    fi
+    sleep 5
+  done
+}
+
 PRIMARY_PAUSED=0
 BUCKET_NAME="$(generate_bucket_name "e2e-obj-failover")"
 BUCKET_URL="moca://${BUCKET_NAME}"
@@ -469,21 +520,28 @@ if [ "$GVG_COUNT" != "0" ]; then
     echo "FAIL: recover-vgf reported an error"
     exit 1
   fi
+
+  print_test_section "Step 9: wait for successor recovery to complete"
+  if ! recover_process_out="$(wait_for_successor_recover_complete "$SUCCESSOR_CONTAINER" "$BUCKET_FAMILY_ID" 300)"; then
+    echo "FAIL: successor recovery did not finish successfully"
+    exit 1
+  fi
+  echo "$recover_process_out"
 else
   print_test_section "Step 8: skip recover-vgf for empty family"
   print_success "family ${BUCKET_FAMILY_ID} has no GVGs; recover-vgf not needed"
 fi
 
-print_test_section "Step 9: complete swap-in on successor"
+print_test_section "Step 10: complete swap-in on successor"
 complete_swapin_out="$(run_successor_swap_cmd "$SUCCESSOR_CONTAINER" completeSwapIn --config /root/.moca-sp/config.toml --vgf "$BUCKET_FAMILY_ID" --gvgId 0)"
 echo "$complete_swapin_out"
 require_sp_tx_success "completeSwapIn" "$complete_swapin_out"
 
-print_test_section "Step 10: wait for family primary to switch to successor"
+print_test_section "Step 11: wait for family primary to switch to successor"
 NEW_PRIMARY_SP_ID="$(wait_for_gvg_primary_sp_change "$BUCKET_FAMILY_ID" "$BEFORE_PRIMARY_SP_ID" 180)"
 assert_eq "$NEW_PRIMARY_SP_ID" "$SUCCESSOR_SP_ID" "family primary switched to the selected successor SP"
 
-print_test_section "Step 11: verify object get succeeds after manual failover"
+print_test_section "Step 12: verify object get succeeds after manual failover"
 remove_file_docker_aware "$DOWNLOAD_FILE"
 get_out="$(timed_object_get 60 object get "$OBJECT_URL" "$DOWNLOAD_FILE" || true)"
 if [ ! -f "$DOWNLOAD_FILE" ]; then
@@ -496,7 +554,7 @@ SOURCE_SHA="$(sha256_file "$SOURCE_FILE")"
 DOWNLOAD_SHA="$(sha256_file_docker_aware "$DOWNLOAD_FILE" || true)"
 assert_eq "$DOWNLOAD_SHA" "$SOURCE_SHA" "downloaded object matches original sha256"
 
-print_test_section "Step 12: resume original primary container"
+print_test_section "Step 13: resume original primary container"
 docker unpause "$PRIMARY_SP_CONTAINER" >/dev/null
 PRIMARY_PAUSED=0
 print_success "primary container resumed"

--- a/tests/test_storage_object_failover.sh
+++ b/tests/test_storage_object_failover.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# E2E: manual object failover after the primary SP becomes unavailable.
+# E2E: manual object failover after the primary SP is forced to exit and its endpoint becomes unavailable.
 set -euo pipefail
 
 ENV="${1:-local}"
@@ -95,6 +95,230 @@ remove_file_docker_aware() {
   if [ -e "$path" ] && [[ "$MOCA_CMD_TARGET" == docker:* ]]; then
     docker exec "${MOCA_CMD_TARGET#docker:}" rm -f "$path" >/dev/null 2>&1 || true
     rm -f "$path" >/dev/null 2>&1 || true
+  fi
+}
+
+timed_object_get() {
+  local timeout_seconds="${1:?timeout seconds required}"
+  shift
+
+  if [[ "$MOCA_CMD_TARGET" == docker:* ]]; then
+    local container="${MOCA_CMD_TARGET#docker:}"
+    docker exec "$container" sh -lc '
+      timeout="$1"
+      shift
+      exec timeout "$timeout" moca-cmd -p /root/.moca-cmd/password.txt "$@"
+    ' sh "$timeout_seconds" "$@" 2>/dev/null
+    return $?
+  fi
+
+  exec_moca_cmd_signed "$@"
+}
+
+exec_validator_mocad() {
+  local validator_index="${1:?validator index required}"
+  shift
+  docker exec "validator-${validator_index}" mocad "$@" --home /root/.mocad 2>/dev/null
+}
+
+current_proposal_count() {
+  exec_mocad query gov proposals --node "$TM_RPC" --output json 2>/dev/null \
+    | jq -r '.proposals | length // 0' 2>/dev/null || echo "0"
+}
+
+latest_proposal_id() {
+  exec_mocad query gov proposals --node "$TM_RPC" --output json 2>/dev/null \
+    | jq -r '.proposals[-1].id // .proposals[-1].proposal_id // empty' 2>/dev/null || true
+}
+
+gov_module_authority() {
+  local authority
+
+  authority="$(exec_mocad query auth module-account gov --node "$TM_RPC" --output json 2>/dev/null \
+    | jq -r '.account.base_account.address // .account.value.address // empty' 2>/dev/null || true)"
+  if [ -n "$authority" ]; then
+    printf '%s\n' "$authority"
+    return 0
+  fi
+
+  authority="$(exec_mocad query auth module-accounts --node "$TM_RPC" --output json 2>/dev/null \
+    | jq -r '.accounts[]? | select(.name == "gov") | .base_account.address // .value.address // empty' 2>/dev/null || true)"
+  if [ -n "$authority" ]; then
+    printf '%s\n' "$authority"
+    return 0
+  fi
+
+  return 1
+}
+
+gov_min_deposit() {
+  local gov_params amount denom
+
+  gov_params="$(exec_mocad query gov params --node "$TM_RPC" --output json 2>/dev/null || echo '{}')"
+  amount="$(printf '%s\n' "$gov_params" | jq -r '.params.min_deposit[0].amount // .deposit_params.min_deposit[0].amount // empty' 2>/dev/null || true)"
+  denom="$(printf '%s\n' "$gov_params" | jq -r '.params.min_deposit[0].denom // .deposit_params.min_deposit[0].denom // empty' 2>/dev/null || true)"
+  if [ -z "$amount" ] || [ -z "$denom" ]; then
+    return 1
+  fi
+
+  printf '%s%s\n' "$amount" "$denom"
+}
+
+wait_for_proposal_status() {
+  local proposal_id="${1:?proposal id required}"
+  local expected_status="${2:?expected status required}"
+  local timeout="${3:-60}"
+  local deadline now current
+
+  deadline=$(( $(date +%s) + timeout ))
+  while :; do
+    current="$(exec_mocad query gov proposal "$proposal_id" --node "$TM_RPC" --output json 2>/dev/null \
+      | jq -r '.proposal.status // empty' 2>/dev/null || true)"
+    if [ "$current" = "$expected_status" ]; then
+      return 0
+    fi
+    now=$(date +%s)
+    if [ "$now" -ge "$deadline" ]; then
+      echo "  wait_for_proposal_status: timeout after ${timeout}s; proposal ${proposal_id} status=${current:-unknown}" >&2
+      return 1
+    fi
+    sleep 2
+  done
+}
+
+submit_forced_exit_proposal() {
+  local target_operator="${1:?target operator required}"
+  local gov_authority deposit before_count after_count proposal_id submit_out tmpfile validator_count validator_name vote_out
+  local proposal_json=""
+
+  gov_authority="$(gov_module_authority || true)"
+  if [ -z "$gov_authority" ]; then
+    echo "FAIL: could not determine gov module authority"
+    exit 1
+  fi
+
+  deposit="$(gov_min_deposit || true)"
+  if [ -z "$deposit" ]; then
+    echo "FAIL: could not determine governance min deposit"
+    exit 1
+  fi
+
+  before_count="$(current_proposal_count)"
+  tmpfile="/tmp/forced-exit-proposal-${PRIMARY_SP_CONTAINER}.json"
+  proposal_json=$(cat <<EOF
+{
+  "messages": [
+    {
+      "@type": "/moca.virtualgroup.MsgStorageProviderForcedExit",
+      "authority": "${gov_authority}",
+      "storageProvider": "${target_operator}"
+    }
+  ],
+  "deposit": "${deposit}",
+  "title": "E2E forced exit for ${PRIMARY_SP_CONTAINER}",
+  "summary": "Force ${PRIMARY_SP_CONTAINER} to exit before manual object failover"
+}
+EOF
+)
+
+  printf '%s\n' "$proposal_json" | docker exec -i validator-0 sh -lc "cat > ${tmpfile}"
+  submit_out="$(exec_validator_mocad 0 tx gov submit-proposal "${tmpfile}" \
+    --from validator0 \
+    --keyring-backend test \
+    --chain-id "$CHAIN_ID" \
+    --node tcp://localhost:26657 \
+    --fees "$FEES" \
+    -y 2>&1 || true)"
+  echo "$submit_out"
+  sleep 5
+
+  after_count="$(current_proposal_count)"
+  if [ "$after_count" -le "$before_count" ] 2>/dev/null; then
+    echo "FAIL: forced-exit proposal was not created"
+    exit 1
+  fi
+
+  proposal_id="$(latest_proposal_id)"
+  if [ -z "$proposal_id" ]; then
+    echo "FAIL: could not resolve forced-exit proposal id"
+    exit 1
+  fi
+  print_success "forced-exit proposal created (id=${proposal_id})"
+
+  validator_count="$(docker ps --format '{{.Names}}' 2>/dev/null | grep -Ec '^validator-[0-9]+$')"
+  if [ -z "$validator_count" ] || [ "$validator_count" -eq 0 ] 2>/dev/null; then
+    echo "FAIL: could not find validator containers to vote on proposal ${proposal_id}"
+    exit 1
+  fi
+
+  for validator_name in $(docker ps --format '{{.Names}}' 2>/dev/null | grep -E '^validator-[0-9]+$' | sort -V); do
+    vote_out="$(docker exec "$validator_name" mocad tx gov vote "$proposal_id" yes \
+      --from "validator${validator_name#validator-}" \
+      --keyring-backend test \
+      --chain-id "$CHAIN_ID" \
+      --node tcp://localhost:26657 \
+      --fees "$FEES" \
+      --home /root/.mocad \
+      -y 2>&1 || true)"
+    echo "$vote_out"
+  done
+
+  if ! wait_for_proposal_status "$proposal_id" "PROPOSAL_STATUS_PASSED" 60; then
+    echo "FAIL: forced-exit proposal ${proposal_id} did not pass"
+    exit 1
+  fi
+  print_success "forced-exit proposal passed"
+}
+
+extract_evm_tx_hash_from_output() {
+  printf '%s\n' "${1:-}" | grep -oE '0x[0-9a-fA-F]{64}' | head -1
+}
+
+wait_for_evm_receipt_status() {
+  local tx_hash="${1:?tx hash required}"
+  local timeout="${2:-30}"
+  local deadline now receipt status
+
+  deadline=$(( $(date +%s) + timeout ))
+  while :; do
+    receipt="$(_evm_rpc eth_getTransactionReceipt "[\"$tx_hash\"]")"
+    if [ -n "$receipt" ] && [ "$receipt" != "null" ]; then
+      status="$(printf '%s\n' "$receipt" | jq -r '.status // empty' 2>/dev/null || true)"
+      if [ -n "$status" ]; then
+        printf '%s\n' "$status"
+        return 0
+      fi
+    fi
+    now=$(date +%s)
+    if [ "$now" -ge "$deadline" ]; then
+      return 1
+    fi
+    sleep 1
+  done
+}
+
+require_sp_tx_success() {
+  local step_name="${1:?step name required}"
+  local cmd_output="${2:-}"
+  local tx_hash receipt_status
+
+  tx_hash="$(extract_evm_tx_hash_from_output "$cmd_output")"
+  if [ -z "$tx_hash" ]; then
+    echo "$cmd_output"
+    echo "FAIL: ${step_name} did not emit a transaction hash"
+    exit 1
+  fi
+
+  receipt_status="$(wait_for_evm_receipt_status "$tx_hash" 30 || true)"
+  if [ -z "$receipt_status" ]; then
+    echo "$cmd_output"
+    echo "FAIL: ${step_name} tx ${tx_hash} did not produce a receipt in time"
+    exit 1
+  fi
+  if [ "$receipt_status" != "0x1" ]; then
+    echo "$cmd_output"
+    echo "FAIL: ${step_name} tx ${tx_hash} reverted on-chain (status=${receipt_status})"
+    exit 1
   fi
 }
 
@@ -263,15 +487,23 @@ if [ -z "$SUCCESSOR_OPERATOR" ] || [ "$SUCCESSOR_OPERATOR" = "null" ]; then
 fi
 print_success "selected successor ${SUCCESSOR_CONTAINER} (sp_id=${SUCCESSOR_SP_ID}) for manual failover"
 
-print_test_section "Step 4: pause primary SP container"
+print_test_section "Step 4: force the primary SP into on-chain exiting status"
+submit_forced_exit_proposal "$PRIMARY_SP"
+if ! wait_for_sp_status "$PRIMARY_SP" "STATUS_FORCED_EXITING" 180; then
+  echo "FAIL: primary SP never entered STATUS_FORCED_EXITING"
+  exit 1
+fi
+print_success "primary SP entered STATUS_FORCED_EXITING"
+
+print_test_section "Step 5: pause primary SP container"
 docker pause "$PRIMARY_SP_CONTAINER" >/dev/null
 PRIMARY_PAUSED=1
 sleep 3
 print_success "primary container paused"
 
-print_test_section "Step 5: verify forced primary endpoint is unavailable"
+print_test_section "Step 6: verify forced primary endpoint is unavailable"
 remove_file_docker_aware "$PRIMARY_ONLY_DOWNLOAD_FILE"
-if primary_get_out="$(exec_moca_cmd_signed object get --spEndpoint "$PRIMARY_SP_ENDPOINT" "$OBJECT_URL" "$PRIMARY_ONLY_DOWNLOAD_FILE")"; then
+if primary_get_out="$(timed_object_get 20 object get --spEndpoint "$PRIMARY_SP_ENDPOINT" "$OBJECT_URL" "$PRIMARY_ONLY_DOWNLOAD_FILE")"; then
   echo "$primary_get_out"
   echo "FAIL: object get unexpectedly succeeded when forced to use paused primary endpoint ${PRIMARY_SP_ENDPOINT}"
   exit 1
@@ -279,16 +511,13 @@ fi
 remove_file_docker_aware "$PRIMARY_ONLY_DOWNLOAD_FILE"
 print_success "forced primary endpoint download failed as expected"
 
-print_test_section "Step 6: manually reserve swap-in on successor"
+print_test_section "Step 7: manually reserve swap-in on successor"
 swapin_out="$(run_successor_swap_cmd "$SUCCESSOR_CONTAINER" swapIn --config /root/.moca-sp/config.toml --vgf "$BUCKET_FAMILY_ID" --gvgId 0 --targetSP "$PRIMARY_SP_ID")"
 echo "$swapin_out"
-if ! printf '%s\n' "$swapin_out" | grep -qiE 'tx hash|txhash|broadcast|success'; then
-  echo "FAIL: swapIn did not report a successful submission"
-  exit 1
-fi
+require_sp_tx_success "swapIn" "$swapin_out"
 
 if [ "$GVG_COUNT" != "0" ]; then
-  print_test_section "Step 7: recover family on successor"
+  print_test_section "Step 8: recover family on successor"
   recover_out="$(run_successor_swap_cmd "$SUCCESSOR_CONTAINER" recover-vgf --config /root/.moca-sp/config.toml --vgf "$BUCKET_FAMILY_ID")"
   echo "$recover_out"
   if printf '%s\n' "$recover_out" | grep -qiE 'panic|fatal|error'; then
@@ -296,25 +525,22 @@ if [ "$GVG_COUNT" != "0" ]; then
     exit 1
   fi
 else
-  print_test_section "Step 7: skip recover-vgf for empty family"
+  print_test_section "Step 8: skip recover-vgf for empty family"
   print_success "family ${BUCKET_FAMILY_ID} has no GVGs; recover-vgf not needed"
 fi
 
-print_test_section "Step 8: complete swap-in on successor"
+print_test_section "Step 9: complete swap-in on successor"
 complete_swapin_out="$(run_successor_swap_cmd "$SUCCESSOR_CONTAINER" completeSwapIn --config /root/.moca-sp/config.toml --vgf "$BUCKET_FAMILY_ID" --gvgId 0)"
 echo "$complete_swapin_out"
-if ! printf '%s\n' "$complete_swapin_out" | grep -qiE 'tx hash|txhash|broadcast|success'; then
-  echo "FAIL: completeSwapIn did not report a successful submission"
-  exit 1
-fi
+require_sp_tx_success "completeSwapIn" "$complete_swapin_out"
 
-print_test_section "Step 9: wait for family primary to switch to successor"
+print_test_section "Step 10: wait for family primary to switch to successor"
 NEW_PRIMARY_SP_ID="$(wait_for_gvg_primary_sp_change "$BUCKET_FAMILY_ID" "$BEFORE_PRIMARY_SP_ID" 180)"
 assert_eq "$NEW_PRIMARY_SP_ID" "$SUCCESSOR_SP_ID" "family primary switched to the selected successor SP"
 
-print_test_section "Step 10: verify object get succeeds after manual failover"
+print_test_section "Step 11: verify object get succeeds after manual failover"
 remove_file_docker_aware "$DOWNLOAD_FILE"
-get_out="$(exec_moca_cmd_signed object get "$OBJECT_URL" "$DOWNLOAD_FILE" || true)"
+get_out="$(timed_object_get 60 object get "$OBJECT_URL" "$DOWNLOAD_FILE" || true)"
 if [ ! -f "$DOWNLOAD_FILE" ]; then
   echo "$get_out"
   echo "FAIL: object get did not produce a downloaded file after manual failover"
@@ -325,7 +551,7 @@ SOURCE_SHA="$(sha256_file "$SOURCE_FILE")"
 DOWNLOAD_SHA="$(sha256_file_docker_aware "$DOWNLOAD_FILE" || true)"
 assert_eq "$DOWNLOAD_SHA" "$SOURCE_SHA" "downloaded object matches original sha256"
 
-print_test_section "Step 11: resume original primary container"
+print_test_section "Step 12: resume original primary container"
 docker unpause "$PRIMARY_SP_CONTAINER" >/dev/null
 PRIMARY_PAUSED=0
 print_success "primary container resumed"

--- a/tests/test_storage_object_failover.sh
+++ b/tests/test_storage_object_failover.sh
@@ -29,6 +29,12 @@ if [ "$NUM_SPS" -lt 3 ]; then
   exit 0
 fi
 
+IN_SERVICE_SP_COUNT="$(printf '%s\n' "$SP_CHECK" | jq -r '[.sps[] | select(.status == "STATUS_IN_SERVICE" or .status == 0 or .status == "0")] | length' 2>/dev/null || echo "0")"
+if [ "${IN_SERVICE_SP_COUNT:-0}" -lt 7 ]; then
+  echo "SKIP: manual object failover test needs 7 IN_SERVICE SPs to create a fresh family on local stack (have ${IN_SERVICE_SP_COUNT:-0})"
+  exit 0
+fi
+
 PRIMARY_SP_CONTAINER="sp-0"
 PRIMARY_SP_EXPECTED_ENDPOINT="http://${PRIMARY_SP_CONTAINER}:9033"
 PRIMARY_SP="$(printf '%s\n' "$SP_CHECK" | jq -r --arg primary_container "$PRIMARY_SP_CONTAINER" --arg expected_endpoint "$PRIMARY_SP_EXPECTED_ENDPOINT" '.sps[] | select((.status == "STATUS_IN_SERVICE" or .status == 0 or .status == "0") and ((.description.moniker // "") == $primary_container or (.endpoint // "") == $expected_endpoint)) | .operator_address' 2>/dev/null | head -1)"

--- a/tests/test_storage_object_failover.sh
+++ b/tests/test_storage_object_failover.sh
@@ -35,6 +35,11 @@ if [ -z "$PRIMARY_SP" ] || [ "$PRIMARY_SP" = "null" ]; then
   echo "SKIP: cannot resolve operator for local primary SP container ${PRIMARY_SP_CONTAINER}"
   exit 0
 fi
+PRIMARY_SP_ENDPOINT="$(printf '%s\n' "$SP_CHECK" | jq -r '.sps[] | select((.status == "STATUS_IN_SERVICE" or .status == 0 or .status == "0") and (.endpoint | tostring | test(":9033$"))) | .endpoint' 2>/dev/null | head -1)"
+if [ -z "$PRIMARY_SP_ENDPOINT" ] || [ "$PRIMARY_SP_ENDPOINT" = "null" ]; then
+  echo "SKIP: cannot resolve endpoint for local primary SP container ${PRIMARY_SP_CONTAINER}"
+  exit 0
+fi
 
 sha256_file() {
   local path="${1:?path required}"
@@ -80,6 +85,7 @@ OBJECT_NAME="failover-object.txt"
 OBJECT_URL="${BUCKET_URL}/${OBJECT_NAME}"
 SOURCE_FILE="$(create_test_file "/tmp/${BUCKET_NAME}-${OBJECT_NAME}" "storage failover $(date)")"
 DOWNLOAD_FILE="/tmp/${BUCKET_NAME}-${OBJECT_NAME}.downloaded"
+PRIMARY_ONLY_DOWNLOAD_FILE="/tmp/${BUCKET_NAME}-${OBJECT_NAME}.primary-only"
 
 cleanup() {
   if [ "$PRIMARY_PAUSED" = "1" ]; then
@@ -88,6 +94,7 @@ cleanup() {
   fi
   rm -f "$SOURCE_FILE" >/dev/null 2>&1 || true
   remove_file_docker_aware "$DOWNLOAD_FILE"
+  remove_file_docker_aware "$PRIMARY_ONLY_DOWNLOAD_FILE"
   exec_moca_cmd_signed bucket rm "$BUCKET_URL" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
@@ -115,7 +122,17 @@ PRIMARY_PAUSED=1
 sleep 3
 print_success "primary container paused"
 
-print_test_section "Step 4: get object through secondary failover"
+print_test_section "Step 4: verify primary endpoint is unavailable"
+remove_file_docker_aware "$PRIMARY_ONLY_DOWNLOAD_FILE"
+if primary_get_out="$(exec_moca_cmd_signed object get --spEndpoint "$PRIMARY_SP_ENDPOINT" "$OBJECT_URL" "$PRIMARY_ONLY_DOWNLOAD_FILE")"; then
+  echo "$primary_get_out"
+  echo "FAIL: object get unexpectedly succeeded when forced to use paused primary endpoint ${PRIMARY_SP_ENDPOINT}"
+  exit 1
+fi
+remove_file_docker_aware "$PRIMARY_ONLY_DOWNLOAD_FILE"
+print_success "forced primary endpoint download failed as expected"
+
+print_test_section "Step 5: get object through secondary failover"
 get_out="$(exec_moca_cmd_signed object get "$OBJECT_URL" "$DOWNLOAD_FILE" || true)"
 if [ ! -f "$DOWNLOAD_FILE" ]; then
   echo "$get_out"
@@ -127,7 +144,7 @@ SOURCE_SHA="$(sha256_file "$SOURCE_FILE")"
 DOWNLOAD_SHA="$(sha256_file_docker_aware "$DOWNLOAD_FILE" || true)"
 assert_eq "$DOWNLOAD_SHA" "$SOURCE_SHA" "downloaded object matches original sha256"
 
-print_test_section "Step 5: unpause primary SP container"
+print_test_section "Step 6: unpause primary SP container"
 docker unpause "$PRIMARY_SP_CONTAINER" >/dev/null
 PRIMARY_PAUSED=0
 print_success "primary container resumed"

--- a/tests/test_storage_object_failover.sh
+++ b/tests/test_storage_object_failover.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# E2E: object read failover when the primary SP is unreachable.
+# E2E: successor SP takes over a primary SP and keeps object reads available.
 set -euo pipefail
 
 ENV="${1:-local}"
@@ -19,25 +19,32 @@ if ! resolve_moca_cmd >/dev/null 2>&1; then
   echo "SKIP: moca-cmd required for object get failover"
   exit 0
 fi
-MOCA_CMD_TARGET="$(resolve_moca_cmd 2>/dev/null || true)"
 
 SP_CHECK="$(exec_mocad query sp storage-providers --node "$TM_RPC" --output json 2>/dev/null || echo "")"
 NUM_SPS="$(echo "$SP_CHECK" | jq -r '.sps | length // 0' 2>/dev/null || echo "0")"
 NUM_SPS="${NUM_SPS:-0}"
 if [ "$NUM_SPS" -lt 3 ]; then
-  echo "SKIP: object failover needs primary + 2 secondaries (have ${NUM_SPS} SPs)"
+  echo "SKIP: object failover needs primary + successors (have ${NUM_SPS} SPs)"
   exit 0
 fi
 
 PRIMARY_SP_CONTAINER="sp-0"
-PRIMARY_SP="$(printf '%s\n' "$SP_CHECK" | jq -r '.sps[] | select((.status == "STATUS_IN_SERVICE" or .status == 0 or .status == "0") and (.endpoint | tostring | test(":9033$"))) | .operator_address' 2>/dev/null | head -1)"
+PRIMARY_SP_EXPECTED_ENDPOINT="http://${PRIMARY_SP_CONTAINER}:9033"
+PRIMARY_SP="$(printf '%s\n' "$SP_CHECK" | jq -r --arg primary_container "$PRIMARY_SP_CONTAINER" --arg expected_endpoint "$PRIMARY_SP_EXPECTED_ENDPOINT" '.sps[] | select((.status == "STATUS_IN_SERVICE" or .status == 0 or .status == "0") and ((.description.moniker // "") == $primary_container or (.endpoint // "") == $expected_endpoint)) | .operator_address' 2>/dev/null | head -1)"
 if [ -z "$PRIMARY_SP" ] || [ "$PRIMARY_SP" = "null" ]; then
   echo "SKIP: cannot resolve operator for local primary SP container ${PRIMARY_SP_CONTAINER}"
   exit 0
 fi
-PRIMARY_SP_ENDPOINT="$(printf '%s\n' "$SP_CHECK" | jq -r '.sps[] | select((.status == "STATUS_IN_SERVICE" or .status == 0 or .status == "0") and (.endpoint | tostring | test(":9033$"))) | .endpoint' 2>/dev/null | head -1)"
-if [ -z "$PRIMARY_SP_ENDPOINT" ] || [ "$PRIMARY_SP_ENDPOINT" = "null" ]; then
-  echo "SKIP: cannot resolve endpoint for local primary SP container ${PRIMARY_SP_CONTAINER}"
+
+PRIMARY_SP_ID="$(printf '%s\n' "$SP_CHECK" | jq -r --arg primary_operator "$PRIMARY_SP" '.sps[] | select(.operator_address == $primary_operator) | .id' 2>/dev/null | head -1)"
+if [ -z "$PRIMARY_SP_ID" ] || [ "$PRIMARY_SP_ID" = "null" ]; then
+  echo "SKIP: cannot resolve SP ID for local primary SP container ${PRIMARY_SP_CONTAINER}"
+  exit 0
+fi
+
+PRIMARY_STATUS="$(get_sp_status_by_operator "$PRIMARY_SP")"
+if [ "$PRIMARY_STATUS" != "STATUS_IN_SERVICE" ] && [ "$PRIMARY_STATUS" != "0" ]; then
+  echo "SKIP: local primary SP ${PRIMARY_SP_CONTAINER} is not IN_SERVICE (status=${PRIMARY_STATUS:-unknown})"
   exit 0
 fi
 
@@ -50,51 +57,66 @@ sha256_file() {
   shasum -a 256 "$path" | awk '{print $1}'
 }
 
-sha256_file_docker_aware() {
-  local path="${1:?path required}"
-  if [ -r "$path" ]; then
-    sha256_file "$path"
-    return 0
-  fi
-  if [[ "$MOCA_CMD_TARGET" == docker:* ]]; then
-    docker exec "${MOCA_CMD_TARGET#docker:}" sh -lc '
-      if command -v sha256sum >/dev/null 2>&1; then
-        sha256sum "$1" | awk "{print \$1}"
-      else
-        shasum -a 256 "$1" | awk "{print \$1}"
-      fi
-    ' sh "$path" 2>/dev/null
-    return $?
-  fi
-  return 1
+gvg_primary_sp_id_by_family() {
+  local family_id="${1:?family id required}"
+  exec_mocad query virtualgroup global-virtual-group-by-family-id "$family_id" \
+    --node "$TM_RPC" --output json 2>/dev/null \
+    | jq -r '.global_virtual_groups[0].primary_sp_id // empty' 2>/dev/null || true
 }
 
-remove_file_docker_aware() {
-  local path="${1:?path required}"
-  rm -f "$path" >/dev/null 2>&1 || true
-  if [ -e "$path" ] && [[ "$MOCA_CMD_TARGET" == docker:* ]]; then
-    docker exec "${MOCA_CMD_TARGET#docker:}" rm -f "$path" >/dev/null 2>&1 || true
-    rm -f "$path" >/dev/null 2>&1 || true
-  fi
+wait_for_gvg_primary_sp_change() {
+  local family_id="${1:?family id required}"
+  local old_sp_id="${2:?old primary sp id required}"
+  local timeout="${3:-180}"
+  local deadline now current
+
+  deadline=$(( $(date +%s) + timeout ))
+  while :; do
+    current="$(gvg_primary_sp_id_by_family "$family_id")"
+    if [ -n "$current" ] && [ "$current" != "$old_sp_id" ]; then
+      printf '%s\n' "$current"
+      return 0
+    fi
+    now=$(date +%s)
+    if [ "$now" -ge "$deadline" ]; then
+      echo "  wait_for_gvg_primary_sp_change: timeout after ${timeout}s; last primary SP ID: ${current:-unknown}" >&2
+      return 1
+    fi
+    sleep 3
+  done
 }
 
-PRIMARY_PAUSED=0
+wait_for_sp_removed_from_list() {
+  local operator="${1:?operator required}"
+  local timeout="${2:-180}"
+  local deadline now sp_json
+
+  deadline=$(( $(date +%s) + timeout ))
+  while :; do
+    sp_json="$(exec_mocad query sp storage-providers --node "$TM_RPC" --output json 2>/dev/null || echo '{}')"
+    if ! printf '%s\n' "$sp_json" | jq -e --arg op "$operator" '.sps[] | select(.operator_address == $op)' >/dev/null 2>&1; then
+      return 0
+    fi
+    now=$(date +%s)
+    if [ "$now" -ge "$deadline" ]; then
+      echo "  wait_for_sp_removed_from_list: timeout after ${timeout}s; operator still present: ${operator}" >&2
+      return 1
+    fi
+    sleep 3
+  done
+}
+
 BUCKET_NAME="$(generate_bucket_name "e2e-obj-failover")"
 BUCKET_URL="moca://${BUCKET_NAME}"
 OBJECT_NAME="failover-object.txt"
 OBJECT_URL="${BUCKET_URL}/${OBJECT_NAME}"
 SOURCE_FILE="$(create_test_file "/tmp/${BUCKET_NAME}-${OBJECT_NAME}" "storage failover $(date)")"
 DOWNLOAD_FILE="/tmp/${BUCKET_NAME}-${OBJECT_NAME}.downloaded"
-PRIMARY_ONLY_DOWNLOAD_FILE="/tmp/${BUCKET_NAME}-${OBJECT_NAME}.primary-only"
 
 cleanup() {
-  if [ "$PRIMARY_PAUSED" = "1" ]; then
-    docker unpause "$PRIMARY_SP_CONTAINER" >/dev/null 2>&1 || true
-    PRIMARY_PAUSED=0
-  fi
   rm -f "$SOURCE_FILE" >/dev/null 2>&1 || true
-  remove_file_docker_aware "$DOWNLOAD_FILE"
-  remove_file_docker_aware "$PRIMARY_ONLY_DOWNLOAD_FILE"
+  rm -f "$DOWNLOAD_FILE" >/dev/null 2>&1 || true
+  exec_moca_cmd_signed object rm "$OBJECT_URL" >/dev/null 2>&1 || true
   exec_moca_cmd_signed bucket rm "$BUCKET_URL" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
@@ -116,39 +138,97 @@ if ! echo "$put_out" | grep -qiE "object.*created|created on chain|upload"; then
 fi
 print_success "object put completed (SEALED)"
 
-print_test_section "Step 3: pause primary SP container"
-docker pause "$PRIMARY_SP_CONTAINER" >/dev/null
-PRIMARY_PAUSED=1
-sleep 3
-print_success "primary container paused"
-
-print_test_section "Step 4: verify primary endpoint is unavailable"
-remove_file_docker_aware "$PRIMARY_ONLY_DOWNLOAD_FILE"
-if primary_get_out="$(exec_moca_cmd_signed object get --spEndpoint "$PRIMARY_SP_ENDPOINT" "$OBJECT_URL" "$PRIMARY_ONLY_DOWNLOAD_FILE")"; then
-  echo "$primary_get_out"
-  echo "FAIL: object get unexpectedly succeeded when forced to use paused primary endpoint ${PRIMARY_SP_ENDPOINT}"
+print_test_section "Step 3: record pre-exit primary ownership"
+before_bucket_head="$(exec_moca_cmd bucket head "$BUCKET_URL" 2>&1 || true)"
+if ! echo "$before_bucket_head" | grep -q "bucket_name:\"$BUCKET_NAME\""; then
+  echo "$before_bucket_head"
+  echo "FAIL: bucket head did not return the created bucket"
   exit 1
 fi
-remove_file_docker_aware "$PRIMARY_ONLY_DOWNLOAD_FILE"
-print_success "forced primary endpoint download failed as expected"
 
-print_test_section "Step 5: get object through secondary failover"
+BUCKET_FAMILY_ID="$(printf '%s\n' "$before_bucket_head" | awk -F': ' '/^virtual_group_family_id:/ {print $2; exit}')"
+BEFORE_PRIMARY_SP_ID="$(printf '%s\n' "$before_bucket_head" | awk -F': ' '/^primary SP ID:/ {print $2; exit}')"
+if [ -z "$BUCKET_FAMILY_ID" ] || [ -z "$BEFORE_PRIMARY_SP_ID" ]; then
+  echo "$before_bucket_head"
+  echo "FAIL: could not resolve bucket family ID / primary SP ID before exit"
+  exit 1
+fi
+assert_eq "$BEFORE_PRIMARY_SP_ID" "$PRIMARY_SP_ID" "bucket primary SP ID matches target SP before exit"
+
+print_test_section "Step 4: send sp.exit from ${PRIMARY_SP_CONTAINER}"
+sp_exit_out="$(exec_sp_cmd "$PRIMARY_SP_CONTAINER" -c /root/.moca-sp/config.toml sp.exit --operatorAddress "$PRIMARY_SP" 2>&1 || true)"
+if ! echo "$sp_exit_out" | grep -q "send sp exit txn successfully"; then
+  echo "$sp_exit_out"
+  echo "FAIL: moca-sp sp.exit did not return success"
+  exit 1
+fi
+echo "$sp_exit_out"
+
+print_test_section "Step 5: wait for chain status to become graceful exiting"
+if ! wait_for_sp_status "$PRIMARY_SP" "STATUS_GRACEFUL_EXITING" 180; then
+  echo "FAIL: primary SP never entered STATUS_GRACEFUL_EXITING"
+  exit 1
+fi
+print_success "chain status is STATUS_GRACEFUL_EXITING"
+
+print_test_section "Step 6: query successor takeover plan"
+query_out="$(exec_sp_cmd "$PRIMARY_SP_CONTAINER" query.sp.exit -c /root/.moca-sp/config.toml --endpoint localhost:9333 2>&1 || true)"
+echo "$query_out"
+if echo "$query_out" | grep -q "spExitScheduler not exit"; then
+  echo "FAIL: sp exit scheduler was not started"
+  exit 1
+fi
+if ! echo "$query_out" | jq -e '.self_sp_id >= 0' >/dev/null 2>&1; then
+  echo "FAIL: query.sp.exit did not return the expected JSON payload"
+  exit 1
+fi
+SUCCESSOR_IDS="$(echo "$query_out" | jq -r '[.swap_out_dest[]?.successor_sp_id] | unique | .[]' 2>/dev/null || true)"
+
+print_test_section "Step 7: wait for successor SP to become the new primary"
+NEW_PRIMARY_SP_ID="$(wait_for_gvg_primary_sp_change "$BUCKET_FAMILY_ID" "$BEFORE_PRIMARY_SP_ID" 180)"
+assert_ne "$NEW_PRIMARY_SP_ID" "$BEFORE_PRIMARY_SP_ID" "GVG primary SP changed after graceful exit"
+if [ -n "$SUCCESSOR_IDS" ] && ! printf '%s\n' "$SUCCESSOR_IDS" | grep -qx "$NEW_PRIMARY_SP_ID"; then
+  echo "  successor_sp_ids from query.sp.exit:"
+  printf '%s\n' "$SUCCESSOR_IDS" | sed 's/^/    - /'
+  echo "FAIL: bucket migrated to unexpected primary SP ID ${NEW_PRIMARY_SP_ID}"
+  exit 1
+fi
+print_success "bucket primary moved from ${BEFORE_PRIMARY_SP_ID} to successor ${NEW_PRIMARY_SP_ID}"
+
+print_test_section "Step 8: verify object get succeeds after successor takeover"
+rm -f "$DOWNLOAD_FILE" >/dev/null 2>&1 || true
 get_out="$(exec_moca_cmd_signed object get "$OBJECT_URL" "$DOWNLOAD_FILE" || true)"
 if [ ! -f "$DOWNLOAD_FILE" ]; then
   echo "$get_out"
-  echo "FAIL: object get did not produce a downloaded file while primary was paused"
+  echo "FAIL: object get did not succeed after successor takeover"
   exit 1
 fi
 
 SOURCE_SHA="$(sha256_file "$SOURCE_FILE")"
-DOWNLOAD_SHA="$(sha256_file_docker_aware "$DOWNLOAD_FILE" || true)"
+DOWNLOAD_SHA="$(sha256_file "$DOWNLOAD_FILE")"
 assert_eq "$DOWNLOAD_SHA" "$SOURCE_SHA" "downloaded object matches original sha256"
 
-print_test_section "Step 6: unpause primary SP container"
-docker unpause "$PRIMARY_SP_CONTAINER" >/dev/null
-PRIMARY_PAUSED=0
-print_success "primary container resumed"
+print_test_section "Step 9: complete final primary SP exit"
+if wait_for_sp_removed_from_list "$PRIMARY_SP" 90; then
+  print_success "primary SP completed final exit automatically"
+else
+  complete_out="$(exec_sp_cmd "$PRIMARY_SP_CONTAINER" -c /root/.moca-sp/config.toml sp.complete.exit --operatorAddress "$PRIMARY_SP" 2>&1 || true)"
+  echo "$complete_out"
+  if ! echo "$complete_out" | grep -q "send complete sp exit txn successfully"; then
+    if ! wait_for_sp_removed_from_list "$PRIMARY_SP" 30; then
+      echo "FAIL: moca-sp sp.complete.exit did not return success"
+      exit 1
+    fi
+    print_success "primary SP completed final exit automatically while sp.complete.exit was racing"
+  else
+    if ! wait_for_sp_removed_from_list "$PRIMARY_SP" 180; then
+      echo "FAIL: primary SP still exists in chain SP list after complete exit"
+      exit 1
+    fi
+    print_success "primary SP removed from chain SP list after sp.complete.exit"
+  fi
+fi
 
 trap - EXIT
 cleanup
-echo "PASS: storage object failover test completed"
+echo "PASS: storage object failover successor takeover test completed"

--- a/topology/default.yaml
+++ b/topology/default.yaml
@@ -43,7 +43,7 @@ services:
 
 ports:
   rpc_base: 26657
-  grpc_base: 9090
+  grpc_base: 19090
   rest_base: 1317
   evm_rpc_base: 8545
   evm_ws_base: 8560

--- a/topology/minimal.yaml
+++ b/topology/minimal.yaml
@@ -24,7 +24,7 @@ services:
 
 ports:
   rpc_base: 26657
-  grpc_base: 9090
+  grpc_base: 19090
   rest_base: 1317
   evm_rpc_base: 8545
   evm_ws_base: 8560

--- a/topology/stress.yaml
+++ b/topology/stress.yaml
@@ -39,7 +39,7 @@ services:
 
 ports:
   rpc_base: 26657
-  grpc_base: 9090
+  grpc_base: 19090
   rest_base: 1317
   evm_rpc_base: 8545
   evm_ws_base: 8560


### PR DESCRIPTION
## What changed
- add `tests/test_storage_object_failover.sh` to cover manual object failover on the local stack: force the original primary SP into `STATUS_FORCED_EXITING`, pause its container, reserve swap-in on a chosen successor, recover the VGF, complete swap-in, and verify the object can still be downloaded
- wait for `query-recover-p` to report `Successful` with zero failed objects before calling `completeSwapIn`, so the test matches the actual successor recovery contract instead of racing the background recover job
- verify the paused primary endpoint cannot serve the object during failover and compare the post-failover download against the original file with SHA-256
- extract shared download/checksum helpers into `tests/lib.sh` and reuse them in `tests/test_sp_exit.sh`
- strengthen `tests/test_sp_exit.sh` so graceful exit now also verifies the object can be downloaded from the successor endpoint after the original SP exits
- adjust local topology/config wiring needed by the new local-only failover coverage

## Why
Issue #32 is about validating the standard SP exit and successor takeover path with real object readability, not just metadata visibility. The suite previously missed the read path in two important places:
- manual failover after the original primary becomes unavailable
- graceful exit after primary ownership moves to a successor

This PR adds both checks and fixes a test bug we confirmed locally: `recover-vgf` only triggers background recovery, so calling `completeSwapIn` immediately can race recovery and produce a false failure even when the storage-provider logic is healthy.

## Impact
- adds a deterministic local regression test for manual successor takeover and object readability after forced primary unavailability
- upgrades graceful-exit coverage from metadata-only checks to a real successor download check
- reduces false negatives in CI/local runs by waiting for successor recovery completion before finalizing swap-in

## Validation
- `bash -n tests/lib.sh`
- `bash -n tests/test_sp_exit.sh`
- `bash -n tests/test_storage_object_failover.sh`
- `bash tests/test_sp_exit.sh local config/local.yaml`
- `bash tests/test_storage_object_failover.sh local config/local.yaml`

## Notes
- `tests/test_storage_object_failover.sh` is intentionally local-only because it pauses Docker SP containers and depends on the local `moca-cmd` sidecar
- the failover investigation showed the previous failure was a test timing issue, not a missing chain-sync step: the successor needed time to finish background recovery before `completeSwapIn`

Closes #32
