### PR TITLE
chore: fix broken storage provider stack pointer

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,7 @@ components:
     ref: dd7e931ccbec09fad24f7d992933d814a77c205f
   moca-storage-provider:
     repo: mocachain/moca-storage-provider
-    ref: e3b01f09550c26f5bccb494c51101f494401e032
+    ref: 5fcf09fc958c08ea69762edc444de83f294b3d53
   moca-cmd:
     repo: mocachain/moca-cmd
     ref: 56f49dc8490526257f5d8e9b310350f2c262080b


### PR DESCRIPTION
## What changed
- update `stack.yaml` to point `moca-storage-provider` at `5fcf09fc958c08ea69762edc444de83f294b3d53`
- remove the broken `e3b01f09550c26f5bccb494c51101f494401e032` ref that CI cannot clone from the repository

## Why
`Test Stack` was failing before any E2E test execution in the `Clone repos at stack.yaml refs` step with:

```text
fatal: unable to read tree (e3b01f09550c26f5bccb494c51101f494401e032)
```

That SHA exists as `moca-storage-provider` PR head metadata, but it is not usable as the checked-out stack pointer in CI. The replacement SHA is the `moca-storage-provider` commit used by the most recent successful `Test Stack` auto stack update run on April 22, 2026.

## Validation
- `git ls-remote git@github.com:mocachain/moca-storage-provider.git`
- verified `5fcf09fc958c08ea69762edc444de83f294b3d53` can be cloned and checked out locally
- verified `clone-repos.sh` successfully progresses through `moca-storage-provider @ 5fcf09fc958c08ea69762edc444de83f294b3d53`

## Impact
This unblocks PR CI by restoring a cloneable `moca-storage-provider` stack pointer without changing any test logic.
