### PR TITLE
chore: update known-good stack pointer

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,7 @@ components:
     ref: dd7e931ccbec09fad24f7d992933d814a77c205f
   moca-storage-provider:
     repo: mocachain/moca-storage-provider
-    ref: b87cb921c5768357ce41cb28915e50b8e1f054ae
+    ref: 1d9de0d2a661531c3439e9b41a4402f11a77f347
   moca-cmd:
     repo: mocachain/moca-cmd
     ref: 56f49dc8490526257f5d8e9b310350f2c262080b


### PR DESCRIPTION
## Auto-generated rolling PR

Updates stack.yaml with latest tested component refs.
Automatically force-pushed when source repos merge to main.

**Do not manually merge** — advance-pointer workflow handles this on green CI.