### PR TITLE
fix(genesis): align denom metadata and evm-chain-id with cosmos/evm moca

### DIFF
--- a/scripts/init-genesis.sh
+++ b/scripts/init-genesis.sh
@@ -44,8 +44,9 @@ TMPFILE=$(mktemp)
 # Replace ALL occurrences of "stake" denom with our denom
 sed -i "s/\"stake\"/\"${DENOM}\"/g" "$GENESIS"
 
-# Set denom_metadata for bank module (required for chain init — name field must not be blank)
-NATIVE_COIN_DESC="{\"description\":\"The native staking token of the Moca.\",\"denom_units\":[{\"denom\":\"${DENOM}\",\"exponent\":0,\"aliases\":[\"wei\"]}],\"base\":\"${DENOM}\",\"display\":\"${DENOM}\",\"name\":\"Moca\",\"symbol\":\"MOCA\"}"
+# Set denom_metadata for bank module — mirrors moca's mocaDenomMetadata (app/app.go): cosmos/evm
+# resolves EVM coin decimals from the display unit's exponent, so display must be moca@18.
+NATIVE_COIN_DESC="{\"description\":\"The native staking and EVM token of the Moca chain\",\"denom_units\":[{\"denom\":\"${DENOM}\",\"exponent\":0},{\"denom\":\"moca\",\"exponent\":18}],\"base\":\"${DENOM}\",\"display\":\"moca\",\"name\":\"moca\",\"symbol\":\"MOCA\"}"
 jq --argjson meta "[${NATIVE_COIN_DESC}]" '.app_state.bank.denom_metadata = $meta' "$GENESIS" > "$TMPFILE" && mv "$TMPFILE" "$GENESIS"
 
 # Set governance params
@@ -346,6 +347,10 @@ for i in $(seq 0 $((NUM_VALIDATORS - 1))); do
   sed -i "s|src-chain-id = 1|src-chain-id = ${SRC_CHAIN_ID:-5151}|" "$VOUT/config/app.toml"
   sed -i "s|dest-bsc-chain-id = 2|dest-bsc-chain-id = 97|" "$VOUT/config/app.toml"
   sed -i "s|dest-op-chain-id = 3|dest-op-chain-id = 5611|" "$VOUT/config/app.toml"
+
+  # Patch app.toml — EIP-155 EVM chain id (cosmos/evm; default 0 falls back to 262144).
+  # No-op on older moca refs where the key doesn't exist.
+  sed -i "s|^evm-chain-id = .*|evm-chain-id = ${SRC_CHAIN_ID:-5151}|" "$VOUT/config/app.toml"
 
   # Patch app.toml — minimum gas prices
   sed -i "s|minimum-gas-prices = \".*\"|minimum-gas-prices = \"0${DENOM}\"|" "$VOUT/config/app.toml"


### PR DESCRIPTION
## Why

Rolling PR #49 (moca `58764f8b` → `4ce8b3f6`, the cosmos/evm v0.6.0 migration window) fails: **every validator panics at InitGenesis**:

```
panic: setting EVM coin decimals: received unsupported decimals: 0
  github.com/cosmos/evm/x/vm.SetGlobalConfigVariables(...)  x/vm/module.go:228
  github.com/cosmos/evm/x/vm.InitGenesis.func1()            x/vm/genesis.go:69
```

cosmos/evm's `LoadEvmCoinInfo` resolves the EVM coin decimals from the bank denom-metadata unit matching `display`. Our hand-rolled metadata had only `amoca@0` with `display: amoca` → decimals 0 → panic. Before this delta, moca's in-tree x/evm hardcoded 18 decimals and never consulted the metadata, which is why the previous pointer was green.

## What

1. **Mirror moca's `mocaDenomMetadata()`** (`app/app.go`) exactly: units `amoca@0` + `moca@18`, `display: moca`. This also matches what `migrateToV2` writes on cosmovisor upgrade paths, so fresh-genesis and upgraded chains carry identical metadata.
2. **Set `evm-chain-id` in generated app.toml** (new key, default `0` → falls back to cosmos/evm's 262144). The SPs sign every on-chain tx (SealObject, GVG create, exit flows) with the cosmos-derived EIP-155 id (5151) — at 262144 they would all be rejected at CheckTx and the storage suites would fail. The sed reuses the existing `SRC_CHAIN_ID` derivation and is a no-op on older moca refs where the key doesn't exist.

## Validation

- Built mocad @ `4ce8b3f6`; booted a single-validator chain with the **old** metadata → reproduced the exact CI panic; with the **fixed** metadata → InitGenesis passes, blocks produced, `eth_blockNumber`/`eth_chainId` healthy (chain id correct once `evm-chain-id` is set).
- Full delta audit `58764f8b..4ce8b3f6` (genesis/CLI/config surface, SP proto compat at `2cb51af5`, full CI-log sweep of job 86060936021): these two are the **only** blockers; everything else e2e touches is unchanged. The SP binary is unaffected by the proto deletions (it builds against its own older moca module pin).
- Both changes verified compatible with the current (old) stack pointer, so this PR's own e2e run should stay green.

## Notes

- The bridge `src-chain-id`/`dest-*-chain-id` seds are now dead at the new ref (crosschain module removed) but harmless — left as-is to keep this fix minimal; candidate for a follow-up cleanup.
- After this merges, the rolling pointer needs a refresh (`update-stack`) so the #49 successor tests new-moca + this fix together. #49 itself stays approve-only/auto-merge.

Generated with Claude Code
