### PR TITLE
fix(tests): cosmos --gas auto + non-zero min-gas; EVM gas via re-pinned moca-cmd

### DIFF
--- a/docker/entrypoint-sp.sh
+++ b/docker/entrypoint-sp.sh
@@ -93,7 +93,11 @@ for key in SealGasLimit RejectSealGasLimit DiscontinueBucketGasLimit \
           DepositGasLimit DeleteGlobalVirtualGroupGasLimit \
           DelegateCreateObjectGasLimit DelegateUpdateObjectContentGasLimit \
           ReserveSwapInGasLimit CompleteSwapInGasLimit CancelSwapInGasLimit; do
-  sed -i "s|^${key} = 0$|${key} = 180000|" config.toml
+  # 5M, not 180000: since moca #332 the precompiles meter real KV store gas on
+  # top of the flat RequiredGas, so 180000 reverts state-heavy SP ops. Unused
+  # gas is refunded, so the headroom is free. Match any current value (moca-sp
+  # dumps these as 180000, not 0), so the substitution actually applies.
+  sed -i -E "s|^${key} = [0-9]+$|${key} = 5000000|" config.toml
 done
 for key in SealFeeAmount RejectSealFeeAmount DiscontinueBucketFeeAmount \
           CreateGlobalVirtualGroupFeeAmount CompleteMigrateBucketFeeAmount \

--- a/scripts/init-genesis.sh
+++ b/scripts/init-genesis.sh
@@ -352,8 +352,10 @@ for i in $(seq 0 $((NUM_VALIDATORS - 1))); do
   # No-op on older moca refs where the key doesn't exist.
   sed -i "s|^evm-chain-id = .*|evm-chain-id = ${SRC_CHAIN_ID:-5151}|" "$VOUT/config/app.toml"
 
-  # Patch app.toml — minimum gas prices
-  sed -i "s|minimum-gas-prices = \".*\"|minimum-gas-prices = \"0${DENOM}\"|" "$VOUT/config/app.toml"
+  # Patch app.toml — minimum gas prices. Non-zero (5 gwei) so `--gas auto` works:
+  # the fork derives fees from the node's MinGasPrice, and an empty/zero value
+  # makes the CLI's fee parse fail ("invalid decimal coin expression").
+  sed -i "s|minimum-gas-prices = \".*\"|minimum-gas-prices = \"5000000000${DENOM}\"|" "$VOUT/config/app.toml"
 
   # Copy keyring
   cp -r "$VHOME/keyring-test/"* "$VOUT/keyring-test/" 2>/dev/null || true

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,7 +11,7 @@ components:
     ref: 2cb51af59081076bc4ef16122941070816c76e0e
   moca-cmd:
     repo: mocachain/moca-cmd
-    ref: aa2010fce4664ae6e5f41f2813648ae5be34faa3
+    ref: 78d4aef4864964ba14a91126b4073d230f8dfc36
   moca-juno:
     repo: mocachain/moca-juno
     ref: 74e124b2bd80ebaf067c19d6fd293a0bb5b0e8d7

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,7 +11,7 @@ components:
     ref: 2cb51af59081076bc4ef16122941070816c76e0e
   moca-cmd:
     repo: mocachain/moca-cmd
-    ref: 56f49dc8490526257f5d8e9b310350f2c262080b
+    ref: ede7c9c694c326a5deb2a5f1c1c6f8be646c16d7
   moca-juno:
     repo: mocachain/moca-juno
     ref: 74e124b2bd80ebaf067c19d6fd293a0bb5b0e8d7

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,7 +11,7 @@ components:
     ref: 2cb51af59081076bc4ef16122941070816c76e0e
   moca-cmd:
     repo: mocachain/moca-cmd
-    ref: 94b1e79bbeca35ecc07433a36474308daebde165
+    ref: aa2010fce4664ae6e5f41f2813648ae5be34faa3
   moca-juno:
     repo: mocachain/moca-juno
     ref: 74e124b2bd80ebaf067c19d6fd293a0bb5b0e8d7

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,7 +11,7 @@ components:
     ref: 2cb51af59081076bc4ef16122941070816c76e0e
   moca-cmd:
     repo: mocachain/moca-cmd
-    ref: ede7c9c694c326a5deb2a5f1c1c6f8be646c16d7
+    ref: 94b1e79bbeca35ecc07433a36474308daebde165
   moca-juno:
     repo: mocachain/moca-juno
     ref: 74e124b2bd80ebaf067c19d6fd293a0bb5b0e8d7

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,7 +11,7 @@ components:
     ref: 2cb51af59081076bc4ef16122941070816c76e0e
   moca-cmd:
     repo: mocachain/moca-cmd
-    ref: 78d4aef4864964ba14a91126b4073d230f8dfc36
+    ref: a72be2ef0907881ff0e12ff3b70108f0cd754c9d
   moca-juno:
     repo: mocachain/moca-juno
     ref: 74e124b2bd80ebaf067c19d6fd293a0bb5b0e8d7

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,7 +11,7 @@ components:
     ref: 2cb51af59081076bc4ef16122941070816c76e0e
   moca-cmd:
     repo: mocachain/moca-cmd
-    ref: a72be2ef0907881ff0e12ff3b70108f0cd754c9d
+    ref: cbe5b3ccec68162295818da2ee534c23f491af21
   moca-juno:
     repo: mocachain/moca-juno
     ref: 74e124b2bd80ebaf067c19d6fd293a0bb5b0e8d7

--- a/tests/libs/core.sh
+++ b/tests/libs/core.sh
@@ -127,48 +127,77 @@ require_test_key() {
 }
 
 # --- Transaction helpers ---
-# cosmos_tx: broadcast a Cosmos tx in sync mode and wait for on-chain inclusion.
-# Returns 0 only if the tx was included with code=0. Returns 1 on broadcast
-# failure or non-zero on-chain code.
-#
-# Inlines docker-vs-local detection so mocad's stderr reaches our 2>&1 capture
-# (exec_mocad always silences stderr, which would hide real broadcast errors).
-cosmos_tx() {
-  local out hash
+# _cosmos_broadcast: run one `--gas auto` broadcast attempt (docker or local
+# mocad) and echo the raw json/stderr. Split out so cosmos_tx can retry it
+# without duplicating the docker-vs-local detection.
+_cosmos_broadcast() {
   if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^${VALIDATOR_CONTAINER}$"; then
-    out=$(docker exec "$VALIDATOR_CONTAINER" mocad tx "$@" \
+    docker exec "$VALIDATOR_CONTAINER" mocad tx "$@" \
       --home /root/.mocad \
       --keyring-backend test \
       --chain-id "$CHAIN_ID" \
       --node "$TM_RPC" \
+      --gas auto --gas-adjustment 1.5 \
       --fees "$FEES" \
-      --broadcast-mode sync -y --output json 2>&1) || {
-      echo "  cosmos_tx broadcast failed: $out" >&2
-      return 1
-    }
+      --broadcast-mode sync -y --output json 2>&1
   elif command -v mocad >/dev/null 2>&1; then
     local extra_args=()
     [ -n "${MOCAD_HOME:-}" ] && extra_args+=(--home "$MOCAD_HOME")
     [ "${ENV:-local}" != "local" ] && [ -n "${EVM_RPC:-}" ] && extra_args+=(--evm-node "$EVM_RPC")
-    out=$(mocad tx "$@" \
+    mocad tx "$@" \
       "${extra_args[@]}" \
       --keyring-backend test \
       --chain-id "$CHAIN_ID" \
       --node "$TM_RPC" \
+      --gas auto --gas-adjustment 1.5 \
       --fees "$FEES" \
-      --broadcast-mode sync -y --output json 2>&1) || {
-      echo "  cosmos_tx broadcast failed: $out" >&2
-      return 1
-    }
+      --broadcast-mode sync -y --output json 2>&1
   else
-    echo "ERROR: mocad not found (no ${VALIDATOR_CONTAINER} container and no local mocad on PATH)" >&2
+    echo "ERROR: mocad not found (no ${VALIDATOR_CONTAINER} container and no local mocad on PATH)"
     return 127
   fi
-  hash=$(echo "$out" | jq -r '.txhash // empty' 2>/dev/null)
-  if [ -z "$hash" ]; then
-    echo "  cosmos_tx returned no txhash: $out" >&2
-    return 1
-  fi
+}
+
+# cosmos_tx: broadcast a Cosmos tx (with `--gas auto`) and wait for on-chain
+# inclusion. Returns 0 only if included with code=0.
+#
+# Retries the account-sequence-mismatch race: `--gas auto` runs a simulate that
+# reads the signer's sequence at the latest height, which can lag a prior tx's
+# sequence bump by a block on a multi-validator net, so a back-to-back tx signs
+# at a stale sequence. Fixed gas skips the simulate and dodged this; retrying the
+# broadcast (re-simulate at the fresh sequence) is moca's standard remedy.
+cosmos_tx() {
+  local out json hash code raw attempt=0 max_attempts="${COSMOS_TX_RETRIES:-5}"
+  while :; do
+    attempt=$((attempt + 1))
+    # `|| true`: a failed broadcast (e.g. simulate-time sequence mismatch) must
+    # not trip the caller's `set -e` before we inspect $out below.
+    out=$(_cosmos_broadcast "$@") || true
+    if printf '%s' "$out" | grep -qiE "account sequence mismatch|incorrect account sequence"; then
+      if [ "$attempt" -ge "$max_attempts" ]; then
+        echo "  cosmos_tx: sequence mismatch after ${max_attempts} attempts: $out" >&2
+        return 1
+      fi
+      sleep 2
+      continue
+    fi
+    # `--gas auto` prints "gas estimate: N" to stderr, which 2>&1 merges ahead of
+    # the JSON — isolate the JSON line so jq doesn't parse-error (and abort the
+    # caller under set -e). `|| true` guards the empty/no-JSON case likewise.
+    json=$(printf '%s\n' "$out" | grep -E '^\{' | head -1 || true)
+    hash=$(printf '%s' "$json" | jq -r '.txhash // empty' 2>/dev/null || true)
+    if [ -z "$hash" ]; then
+      echo "  cosmos_tx broadcast failed: $out" >&2
+      return 1
+    fi
+    code=$(printf '%s' "$json" | jq -r '.code // empty' 2>/dev/null || true)
+    if [ -n "$code" ] && [ "$code" != "0" ]; then
+      raw=$(printf '%s' "$json" | jq -r '.raw_log // empty' 2>/dev/null || true)
+      echo "  cosmos_tx rejected at CheckTx: code=$code log=$raw" >&2
+      return 1
+    fi
+    break
+  done
   wait_for_cosmos_tx "$hash"
 }
 

--- a/tests/libs/core.sh
+++ b/tests/libs/core.sh
@@ -9,7 +9,6 @@ RPC="${RPC:-http://localhost:26657}"
 REST="${REST:-http://localhost:1317}"
 EVM_RPC="${EVM_RPC:-http://localhost:8545}"
 TM_RPC="${TM_RPC:-$RPC}"
-FEES="${FEES:-200000000000000amoca}"
 VALIDATOR_CONTAINER="${VALIDATOR_CONTAINER:-validator-0}"
 
 # Test key: for local use testaccount (created in genesis), for devnet/testnet use DEVNET_TEST_KEY
@@ -138,7 +137,6 @@ _cosmos_broadcast() {
       --chain-id "$CHAIN_ID" \
       --node "$TM_RPC" \
       --gas auto --gas-adjustment 1.5 \
-      --fees "$FEES" \
       --broadcast-mode sync -y --output json 2>&1
   elif command -v mocad >/dev/null 2>&1; then
     local extra_args=()
@@ -150,7 +148,6 @@ _cosmos_broadcast() {
       --chain-id "$CHAIN_ID" \
       --node "$TM_RPC" \
       --gas auto --gas-adjustment 1.5 \
-      --fees "$FEES" \
       --broadcast-mode sync -y --output json 2>&1
   else
     echo "ERROR: mocad not found (no ${VALIDATOR_CONTAINER} container and no local mocad on PATH)"

--- a/tests/test_payment.sh
+++ b/tests/test_payment.sh
@@ -90,6 +90,7 @@ run_mocad_payment() {
     --keyring-backend test \
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
+    --gas auto --gas-adjustment 1.5 \
     --fees "$FEES" \
     -y 2>/dev/null || echo "FAILED")
 
@@ -131,6 +132,7 @@ run_mocad_payment() {
     --keyring-backend test \
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
+    --gas auto --gas-adjustment 1.5 \
     --fees "$FEES" \
     -y 2>/dev/null || echo "  WARN: deposit may have failed"
   wait_for_tx 5
@@ -146,6 +148,7 @@ run_mocad_payment() {
     --keyring-backend test \
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
+    --gas auto --gas-adjustment 1.5 \
     --fees "$FEES" \
     -y 2>/dev/null || echo "  WARN: withdraw may have failed"
   wait_for_tx 3

--- a/tests/test_payment.sh
+++ b/tests/test_payment.sh
@@ -91,7 +91,6 @@ run_mocad_payment() {
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
     --gas auto --gas-adjustment 1.5 \
-    --fees "$FEES" \
     -y 2>/dev/null || echo "FAILED")
 
   if echo "$CREATE_RESULT" | grep -q "FAILED\|Error\|error"; then
@@ -133,7 +132,6 @@ run_mocad_payment() {
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
     --gas auto --gas-adjustment 1.5 \
-    --fees "$FEES" \
     -y 2>/dev/null || echo "  WARN: deposit may have failed"
   wait_for_tx 5
 
@@ -149,7 +147,6 @@ run_mocad_payment() {
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
     --gas auto --gas-adjustment 1.5 \
-    --fees "$FEES" \
     -y 2>/dev/null || echo "  WARN: withdraw may have failed"
   wait_for_tx 3
 

--- a/tests/test_storage_bucket.sh
+++ b/tests/test_storage_bucket.sh
@@ -50,7 +50,6 @@ run_mocad_bucket_smoke() {
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
     --gas auto --gas-adjustment 1.5 \
-    --fees "$FEES" \
     -y 2>/dev/null || echo "FAILED")
 
   if echo "$create_result" | grep -q "FAILED\|Error\|error"; then
@@ -78,7 +77,6 @@ run_mocad_bucket_smoke() {
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
     --gas auto --gas-adjustment 1.5 \
-    --fees "$FEES" \
     -y 2>/dev/null || true
   wait_for_tx 3
   echo "PASS: storage bucket operations tested (mocad path)"

--- a/tests/test_storage_bucket.sh
+++ b/tests/test_storage_bucket.sh
@@ -49,6 +49,7 @@ run_mocad_bucket_smoke() {
     --keyring-backend test \
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
+    --gas auto --gas-adjustment 1.5 \
     --fees "$FEES" \
     -y 2>/dev/null || echo "FAILED")
 
@@ -76,6 +77,7 @@ run_mocad_bucket_smoke() {
     --keyring-backend test \
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
+    --gas auto --gas-adjustment 1.5 \
     --fees "$FEES" \
     -y 2>/dev/null || true
   wait_for_tx 3

--- a/tests/test_storage_group.sh
+++ b/tests/test_storage_group.sh
@@ -40,7 +40,6 @@ run_mocad_group_smoke() {
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
     --gas auto --gas-adjustment 1.5 \
-    --fees "$FEES" \
     -y 2>/dev/null || echo "FAILED")
 
   if echo "$create_result" | grep -q "FAILED\|Error\|error"; then
@@ -63,7 +62,6 @@ run_mocad_group_smoke() {
       --chain-id "$CHAIN_ID" \
       --node "$TM_RPC" \
       --gas auto --gas-adjustment 1.5 \
-      --fees "$FEES" \
       -y 2>/dev/null || true
     wait_for_tx 3
   fi
@@ -75,7 +73,6 @@ run_mocad_group_smoke() {
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
     --gas auto --gas-adjustment 1.5 \
-    --fees "$FEES" \
     -y 2>/dev/null || true
   wait_for_tx 3
   echo "PASS: storage group operations tested (mocad path)"

--- a/tests/test_storage_group.sh
+++ b/tests/test_storage_group.sh
@@ -39,6 +39,7 @@ run_mocad_group_smoke() {
     --keyring-backend test \
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
+    --gas auto --gas-adjustment 1.5 \
     --fees "$FEES" \
     -y 2>/dev/null || echo "FAILED")
 
@@ -61,6 +62,7 @@ run_mocad_group_smoke() {
       --keyring-backend test \
       --chain-id "$CHAIN_ID" \
       --node "$TM_RPC" \
+      --gas auto --gas-adjustment 1.5 \
       --fees "$FEES" \
       -y 2>/dev/null || true
     wait_for_tx 3
@@ -72,6 +74,7 @@ run_mocad_group_smoke() {
     --keyring-backend test \
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
+    --gas auto --gas-adjustment 1.5 \
     --fees "$FEES" \
     -y 2>/dev/null || true
   wait_for_tx 3

--- a/tests/test_storage_object.sh
+++ b/tests/test_storage_object.sh
@@ -49,6 +49,7 @@ run_mocad_object_smoke() {
     --keyring-backend test \
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
+    --gas auto --gas-adjustment 1.5 \
     --fees "$FEES" \
     -y 2>/dev/null || echo "FAILED")
   if echo "$cr" | grep -q "FAILED\|Error\|error"; then
@@ -62,6 +63,7 @@ run_mocad_object_smoke() {
     --keyring-backend test \
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
+    --gas auto --gas-adjustment 1.5 \
     --fees "$FEES" \
     -y 2>/dev/null || true
   echo "PASS: storage object fallback (bucket smoke only; use moca-cmd for full flow)"

--- a/tests/test_storage_object.sh
+++ b/tests/test_storage_object.sh
@@ -50,7 +50,6 @@ run_mocad_object_smoke() {
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
     --gas auto --gas-adjustment 1.5 \
-    --fees "$FEES" \
     -y 2>/dev/null || echo "FAILED")
   if echo "$cr" | grep -q "FAILED\|Error\|error"; then
     echo "SKIP: mocad bucket create failed; object upload requires moca-cmd"
@@ -64,7 +63,6 @@ run_mocad_object_smoke() {
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
     --gas auto --gas-adjustment 1.5 \
-    --fees "$FEES" \
     -y 2>/dev/null || true
   echo "PASS: storage object fallback (bucket smoke only; use moca-cmd for full flow)"
 }

--- a/tests/test_storage_object_failover.sh
+++ b/tests/test_storage_object_failover.sh
@@ -181,6 +181,7 @@ EOF
     --keyring-backend test \
     --chain-id "$CHAIN_ID" \
     --node tcp://localhost:26657 \
+    --gas auto --gas-adjustment 1.5 \
     --fees "$FEES" \
     -y 2>&1 || true)"
   echo "$submit_out"
@@ -211,6 +212,7 @@ EOF
       --keyring-backend test \
       --chain-id "$CHAIN_ID" \
       --node tcp://localhost:26657 \
+      --gas auto --gas-adjustment 1.5 \
       --fees "$FEES" \
       --home /root/.mocad \
       -y 2>&1 || true)"

--- a/tests/test_storage_object_failover.sh
+++ b/tests/test_storage_object_failover.sh
@@ -182,7 +182,6 @@ EOF
     --chain-id "$CHAIN_ID" \
     --node tcp://localhost:26657 \
     --gas auto --gas-adjustment 1.5 \
-    --fees "$FEES" \
     -y 2>&1 || true)"
   echo "$submit_out"
   sleep 5
@@ -213,7 +212,6 @@ EOF
       --chain-id "$CHAIN_ID" \
       --node tcp://localhost:26657 \
       --gas auto --gas-adjustment 1.5 \
-      --fees "$FEES" \
       --home /root/.mocad \
       -y 2>&1 || true)"
     echo "$vote_out"

--- a/tests/test_storage_policy.sh
+++ b/tests/test_storage_policy.sh
@@ -53,6 +53,7 @@ run_mocad_policy() {
     --keyring-backend test \
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
+    --gas auto --gas-adjustment 1.5 \
     --fees "$FEES" \
     -y 2>/dev/null || {
     echo "SKIP: mocad-only path cannot complete bucket create (install moca-cmd)"
@@ -67,6 +68,7 @@ run_mocad_policy() {
     --keyring-backend test \
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
+    --gas auto --gas-adjustment 1.5 \
     --fees "$FEES" \
     -y 2>/dev/null || true
   wait_for_tx 3
@@ -76,6 +78,7 @@ run_mocad_policy() {
     --keyring-backend test \
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
+    --gas auto --gas-adjustment 1.5 \
     --fees "$FEES" \
     -y 2>/dev/null || true
   echo "PASS: storage permission policy (mocad path)"

--- a/tests/test_storage_policy.sh
+++ b/tests/test_storage_policy.sh
@@ -54,7 +54,6 @@ run_mocad_policy() {
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
     --gas auto --gas-adjustment 1.5 \
-    --fees "$FEES" \
     -y 2>/dev/null || {
     echo "SKIP: mocad-only path cannot complete bucket create (install moca-cmd)"
     exit 0
@@ -69,7 +68,6 @@ run_mocad_policy() {
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
     --gas auto --gas-adjustment 1.5 \
-    --fees "$FEES" \
     -y 2>/dev/null || true
   wait_for_tx 3
 
@@ -79,7 +77,6 @@ run_mocad_policy() {
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
     --gas auto --gas-adjustment 1.5 \
-    --fees "$FEES" \
     -y 2>/dev/null || true
   echo "PASS: storage permission policy (mocad path)"
 }


### PR DESCRIPTION
Supersedes the `--gas 400000` stopgap. Greens the rolling stack at moca main (`e0877cc1`: cosmos/evm + #332) on two gas fronts.

## Cosmos layer
- `init-genesis.sh` sets `minimum-gas-prices=5gwei` so the fork's `--gas auto` fee-override works (an empty/zero `MinGasPrice` was unparseable — `invalid decimal coin expression`).
- The 17 cosmos-tx sites use `--gas auto --gas-adjustment 1.5` (the KV-gas realignment made the old 200000 default OOG; undelegate needs ~220k).
- `cosmos_tx` retries the account-sequence-mismatch race the simulate step reintroduces, and isolates the JSON line before `jq` (`--gas auto` prints `gas estimate:` to stderr, which broke the parse under `set -e`).

## EVM layer
- Since #332 the precompiles meter real KV store gas, so the SP's `180000` pins revert state-heavy ops — `entrypoint-sp.sh` raises them to 5M.
- `stack.yaml` re-pins **moca-cmd** to a `moca-go-sdk` build that estimates EVM precompile gas per call (moca stays `e0877cc1`).

## Dependencies (must merge together / before the stack settles)
- moca-go-sdk: mocachain/moca-go-sdk#27 (EVM gas estimation)
- moca-cmd: mocachain/moca-cmd#20 (re-pin to #27)

## Validation
Full default-topology e2e on an amd64 box against moca `e0877cc1`: **28 passed / 0 failed**. Cosmos `--gas auto` fee = `5gwee × gas_wanted` exactly; EVM ops right-sized (~1.45×) status `0x1`; no reverts.

Generated with Claude Code
