### PR TITLE
ci: bump checkout/upload-artifact to Node 24 majors

### DIFF
--- a/.github/workflows/advance-pointer.yml
+++ b/.github/workflows/advance-pointer.yml
@@ -18,7 +18,7 @@ jobs:
     # Only run on successful check suites
     if: github.event.check_suite.conclusion == 'success'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.E2E_HUB_PAT }}
 

--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install yq
         run: |
@@ -39,7 +39,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-results-${{ github.event.inputs.environment }}
           path: test-results/

--- a/.github/workflows/test-stack.yml
+++ b/.github/workflows/test-stack.yml
@@ -38,7 +38,7 @@ jobs:
       COMPOSE: docker compose -f docker-compose.generated.yml
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install tools
         timeout-minutes: 2
@@ -149,7 +149,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-results
           path: test-results/

--- a/.github/workflows/update-stack.yml
+++ b/.github/workflows/update-stack.yml
@@ -15,7 +15,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: main
           token: ${{ secrets.E2E_HUB_PAT }}


### PR DESCRIPTION
Clears the Node 20 deprecation warning in Actions runs.

- `actions/checkout@v4` → `@v5` (Node 24)
- `actions/upload-artifact@v4` → `@v6` (Node 24; `@v5` is still Node 20)

Verified each target major's `runs.using` is `node24` via the actions' `action.yml`.

Generated with Claude Code
