### PR TITLE
ci: install Foundry so EVM tests actually run

### DIFF
--- a/.github/workflows/test-stack.yml
+++ b/.github/workflows/test-stack.yml
@@ -47,6 +47,12 @@ jobs:
           sudo chmod +x /usr/local/bin/yq
           sudo apt-get install -y jq
 
+      # cast (Foundry) is required by the EVM tests (test_evm_transfer,
+      # test_evm_erc20). Without it they SKIP, silently leaving the EVM path
+      # untested. Installs forge/cast/anvil via the official foundry-rs action.
+      - name: Install Foundry (cast)
+        uses: foundry-rs/foundry-toolchain@v1
+
       - name: Make scripts executable
         run: |
           chmod +x scripts/*.sh


### PR DESCRIPTION
## Problem
`test_evm_transfer.sh` and `test_evm_erc20.sh` skip when `cast` is missing:
```
SKIP: cast (Foundry) not installed
```
Foundry is installed in **no** e2e workflow, so the EVM transfer/ERC20 path is silently untested yet counts toward "28 passed". A regression there would not be caught.

## Fix
Add the official `foundry-rs/foundry-toolchain@v1` step to the e2e job so `cast` is on PATH before `run-suite.sh`. The two EVM tests will now execute instead of skipping.

Generated with Claude Code
