### PR TITLE
fix(e2e): 9-SP topology + GVG-derived sp-exit target so failover doesn't skip

### DIFF
--- a/tests/libs/sp.sh
+++ b/tests/libs/sp.sh
@@ -128,7 +128,7 @@ current_family_count() {
 
 select_target_sp_index() {
   local requested="${E2E_SP_EXIT_INDEX:-}"
-  local candidate_id candidate_idx family_count seen_first
+  local candidate_id candidate_idx family_count
 
   if [ -n "$requested" ] && [ "$requested" -ge 0 ] 2>/dev/null && [ "$requested" -lt "${NUM_SPS:-0}" ] 2>/dev/null; then
     printf '%s\n' "$requested"
@@ -137,21 +137,30 @@ select_target_sp_index() {
 
   family_count="$(current_family_count)"
   if [ "$family_count" = "0" ]; then
-    seen_first=0
-    for candidate_id in $(printf '%s\n' "${SP_JSON:-}" \
-      | jq -r '.sps[] | select(.status == "STATUS_IN_SERVICE" or .status == 0 or .status == "0") | .id' 2>/dev/null | sort -nr); do
-      [ -n "$candidate_id" ] || continue
-      candidate_idx=$((candidate_id - 1))
-      if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^sp-${candidate_idx}$"; then
-        continue
+    # No GVG families exist yet, so we can't see who is a real secondary. Create a
+    # throwaway bucket, read its family's actual secondary SPs, and target one of
+    # those. A fixed pick (e.g. 2nd-highest id) is excluded from a 7-of-N family
+    # once N > 8, which is exactly why 9 SPs broke the sp-exit tests.
+    local probe_primary probe_bucket probe_url probe_head probe_family
+    probe_primary="$(printf '%s\n' "${SP_JSON:-}" \
+      | jq -r '.sps[] | select(.status == "STATUS_IN_SERVICE" or .status == 0 or .status == "0") | .operator_address' 2>/dev/null | head -1)"
+    if [ -n "$probe_primary" ]; then
+      probe_bucket="e2e-sp-exit-probe-$(date +%s)-${RANDOM}"
+      probe_url="moca://${probe_bucket}"
+      if moca_cmd_tx bucket create --primarySP "$probe_primary" "$probe_url" >/dev/null 2>&1; then
+        probe_head="$(exec_moca_cmd bucket head "$probe_url" 2>&1 || true)"
+        probe_family="$(printf '%s\n' "$probe_head" | awk -F': ' '/^virtual_group_family_id:/ {print $2; exit}')"
+        for candidate_id in $(secondary_sp_ids_by_family "${probe_family:-0}" 2>/dev/null | jq -r '.[]?' 2>/dev/null); do
+          candidate_idx=$((candidate_id - 1))
+          if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^sp-${candidate_idx}$"; then
+            exec_moca_cmd bucket rm "$probe_url" >/dev/null 2>&1 || true
+            printf '%s\n' "$candidate_idx"
+            return 0
+          fi
+        done
+        exec_moca_cmd bucket rm "$probe_url" >/dev/null 2>&1 || true
       fi
-      if [ "$seen_first" = "0" ]; then
-        seen_first=1
-        continue
-      fi
-      printf '%s\n' "$candidate_idx"
-      return 0
-    done
+    fi
   fi
 
   for candidate_id in $(printf '%s\n' "${SP_JSON:-}" \

--- a/topology/default.yaml
+++ b/topology/default.yaml
@@ -1,4 +1,4 @@
-# Default topology: 6 validators, 6 SPs
+# Default topology: 6 validators, 9 SPs
 # Used as CI default and baseline for state comparison
 
 chain:
@@ -27,7 +27,8 @@ validators:
 
 storage_providers:
   # Redundancy is 4 data + 2 parity chunks → primary + 6 unique secondaries = 7 SPs minimum.
-  # 8 gives a small rotation margin.
+  # 9 SPs: object failover needs 7 IN_SERVICE, and the two sp-exit tests each take one
+  # out of service before it, so 9 - 2 = 7 keeps it running (8 would drop to 6 → skip).
   - name: sp-0
   - name: sp-1
   - name: sp-2
@@ -36,6 +37,7 @@ storage_providers:
   - name: sp-5
   - name: sp-6
   - name: sp-7
+  - name: sp-8
 
 services:
   mysql:


### PR DESCRIPTION
## Problem
`test_storage_object_failover` **skips** on the default topology: it needs **7 IN_SERVICE SPs** for a fresh GVG family, but `test_sp_exit` + `test_sp_exit_empty_family_blocker` each take an SP out of service before it, so `8 - 2 = 6` → skip. It's a data-durability test (object survives its primary SP being force-exited via governance), so it's worth actually running.

## Fix (two parts)
1. **9-SP default topology** — `9 - 2 = 7` keeps failover running.
2. **GVG-derived sp-exit target** — adding SPs alone broke the sp-exit tests: `select_target_sp_index` picked a fixed high-id SP that a 7-of-9 family excludes, so it could never be placed as a secondary. Now, when no families exist yet, it **creates a probe bucket, reads its GVG family's real `secondary_sp_ids`, and targets one of those** — a real secondary at any SP count.

## Validation
test-box confirmed the probe selects a real secondary (`sp_id=7`) at 9 SPs. The full seal/exit/failover flow is validated here in CI — a 1-validator test-box lagged its block-syncers under 9 SPs, unrelated to the fix.

Generated with Claude Code
