### PR TITLE
chore: update known-good stack pointer

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@
 components:
   moca:
     repo: mocachain/moca
-    ref: d8188cf7c85c1fb2bc51d4e3c032e8bef507cf41
+    ref: 9c0f8fe91cfe900d86a51df1871579f4293ded05
   moca-storage-provider:
     repo: mocachain/moca-storage-provider
     ref: 2cb51af59081076bc4ef16122941070816c76e0e


### PR DESCRIPTION
## Auto-generated rolling PR

Updates stack.yaml with latest tested component refs.
Automatically force-pushed when source repos merge to main.

**Do not manually merge** — advance-pointer workflow handles this on green CI.