### PR TITLE
ci(e2e): build once (GHCR cache) + shard tests into parallel jobs

### DIFF
--- a/.github/workflows/test-stack.yml
+++ b/.github/workflows/test-stack.yml
@@ -24,19 +24,26 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 concurrency:
   group: e2e-test-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-jobs:
-  e2e:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    env:
-      TOPOLOGY: topology/${{ github.event.inputs.topology || 'default' }}.yaml
-      COMPOSE: docker compose -f docker-compose.generated.yml
+env:
+  GHCR_REPO: ghcr.io/${{ github.repository_owner }}/moca-e2e
 
+jobs:
+  # Build the component images once and cache them in this repo's GHCR, keyed by
+  # each component's commit — unchanged components are pulled, not rebuilt. The
+  # sharded e2e jobs below reuse these images instead of each rebuilding.
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      moca_sha: ${{ steps.shas.outputs.moca_sha }}
+      sp_sha: ${{ steps.shas.outputs.sp_sha }}
+      cmd_sha: ${{ steps.shas.outputs.cmd_sha }}
     steps:
       - uses: actions/checkout@v5
 
@@ -47,9 +54,61 @@ jobs:
           sudo chmod +x /usr/local/bin/yq
           sudo apt-get install -y jq
 
-      # cast (Foundry) is required by the EVM tests (test_evm_transfer,
-      # test_evm_erc20). Without it they SKIP, silently leaving the EVM path
-      # untested. Installs forge/cast/anvil via the official foundry-rs action.
+      - name: Make scripts executable
+        run: chmod +x scripts/*.sh
+
+      - name: Clone repos at stack.yaml refs
+        timeout-minutes: 5
+        run: ./scripts/clone-repos.sh stack.yaml
+        env:
+          GH_TOKEN: ${{ secrets.E2E_HUB_PAT }}
+
+      - name: Resolve component SHAs
+        id: shas
+        run: |
+          echo "moca_sha=$(git -C build/moca rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+          echo "sp_sha=$(git -C build/moca-storage-provider rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+          echo "cmd_sha=$(git -C build/moca-cmd rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build and cache images
+        timeout-minutes: 25
+        run: ./scripts/build.sh local
+        env:
+          IMAGE_MODE: cache
+          GH_TOKEN: ${{ secrets.E2E_HUB_PAT }}
+
+  # Run the suite in parallel shards, each on its own 9-SP cluster built from the
+  # pulled images. Wall-clock ≈ the slowest shard instead of the full test phase.
+  e2e:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    name: e2e (${{ matrix.group }})
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [chain, sp, flows]
+    env:
+      TOPOLOGY: topology/${{ github.event.inputs.topology || 'default' }}.yaml
+      COMPOSE: docker compose -f docker-compose.generated.yml
+      IMAGE_MODE: pull
+      MOCA_SHA: ${{ needs.build.outputs.moca_sha }}
+      SP_SHA: ${{ needs.build.outputs.sp_sha }}
+      CMD_SHA: ${{ needs.build.outputs.cmd_sha }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install tools
+        timeout-minutes: 2
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          sudo apt-get install -y jq
+
+      # cast (Foundry) is required by the EVM tests in the chain shard.
       - name: Install Foundry (cast)
         uses: foundry-rs/foundry-toolchain@v1
 
@@ -58,20 +117,15 @@ jobs:
           chmod +x scripts/*.sh
           chmod +x tests/*.sh
 
-      - name: Clone repos at stack.yaml refs
-        timeout-minutes: 5
-        run: ./scripts/clone-repos.sh stack.yaml
-        env:
-          GH_TOKEN: ${{ secrets.E2E_HUB_PAT }}
-
       - name: Generate docker-compose
         run: ./scripts/generate-compose.sh "$TOPOLOGY" docker-compose.generated.yml
 
-      - name: Build images
-        timeout-minutes: 20
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Pull prebuilt images
+        timeout-minutes: 5
         run: ./scripts/build.sh local
-        env:
-          GH_TOKEN: ${{ secrets.E2E_HUB_PAT }}
 
       - name: Run genesis init
         timeout-minutes: 5
@@ -130,7 +184,9 @@ jobs:
           done
 
       - name: Run E2E tests
-        timeout-minutes: 15
+        timeout-minutes: 20
+        env:
+          TEST_GROUP: ${{ matrix.group }}
         run: ./scripts/run-suite.sh local config/local.yaml
 
       - name: Collect logs
@@ -157,7 +213,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: test-results
+          name: test-results-${{ matrix.group }}
           path: test-results/
           retention-days: 7
 

--- a/.github/workflows/test-stack.yml
+++ b/.github/workflows/test-stack.yml
@@ -187,6 +187,9 @@ jobs:
         timeout-minutes: 20
         env:
           TEST_GROUP: ${{ matrix.group }}
+          # CI clusters provide every precondition, so a skipped test is an
+          # unexpected coverage gap — fail the shard rather than pass green.
+          STRICT_SKIPS: "1"
         run: ./scripts/run-suite.sh local config/local.yaml
 
       - name: Collect logs

--- a/docker/Dockerfile.cosmovisor
+++ b/docker/Dockerfile.cosmovisor
@@ -1,25 +1,13 @@
+# cosmovisor image = the already-built mocad binary (reused from mocad-local, NOT
+# recompiled) plus the cosmovisor supervisor. build.sh builds/pulls mocad first, so
+# mocad-local:latest is present in the daemon. This avoids a second full ~10-min moca
+# compile whenever the moca commit changes.
 FROM golang:1.23-bullseye AS builder
 
+# Declared for build-arg compatibility with build.sh; unused here (no moca compile).
 ARG TARGETARCH
 ARG GITHUB_TOKEN=""
 
-RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /build
-
-COPY build/moca/ .
-
-RUN git init && git add -A && git commit -m "build" --allow-empty 2>/dev/null || true
-RUN if [ -n "$GITHUB_TOKEN" ]; then git config --global url."https://${GITHUB_TOKEN}:@github.com/".insteadOf "https://github.com/"; fi
-
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=1 \
-    CGO_CFLAGS="-O -D__BLST_PORTABLE__" \
-    GOARCH=${TARGETARCH} \
-    make build
-
-# Build cosmovisor
 RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@latest
 
 FROM debian:bullseye-slim
@@ -28,7 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl jq \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /build/build/mocad /usr/local/bin/mocad
+COPY --from=mocad-local:latest /usr/local/bin/mocad /usr/local/bin/mocad
 COPY --from=builder /go/bin/cosmovisor /usr/local/bin/cosmovisor
 COPY docker/entrypoint-cosmovisor.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,14 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Builds Docker images for all components from cloned repos.
-# The cloned repos should be in ./build/ (placed there by clone-repos.sh).
+# Builds (or reuses) the component Docker images.
+#
+#   IMAGE_MODE=cache : build job — reuse the GHCR image for a component if its
+#                      source commit is unchanged, otherwise build and push it.
+#   IMAGE_MODE=pull  : shard job — just pull the images the build job produced
+#                      (keyed by the same commits, passed in via *_SHA env).
+#   unset            : local / test-box — plain docker build, no registry.
+#
+# The cache lives entirely in this repo's GHCR namespace ($GHCR_REPO) — the shards
+# never rebuild, and unchanged components are not rebuilt across runs.
 
 ENV="${1:-local}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 BUILD_DIR="$ROOT_DIR/build"
 ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+GHCR_REPO="${GHCR_REPO:-ghcr.io/mocachain/moca-e2e}"
 
 # Pass GITHUB_TOKEN for private dependency resolution in Docker builds
 TOKEN_ARG=""
@@ -18,66 +27,66 @@ elif [ -n "${GITHUB_TOKEN:-}" ]; then
   TOKEN_ARG="--build-arg GITHUB_TOKEN=${GITHUB_TOKEN}"
 fi
 
-echo "=== Building Docker images (arch: $ARCH) ==="
+# Cache keys = the source commit of each built image. Shard (pull) jobs receive
+# these as env (they don't clone); otherwise read them from the cloned repos.
+sha_of() { git -C "$BUILD_DIR/$1" rev-parse --short=12 HEAD 2>/dev/null || echo local; }
+MOCA_SHA="${MOCA_SHA:-$(sha_of moca)}"
+SP_SHA="${SP_SHA:-$(sha_of moca-storage-provider)}"
+CMD_SHA="${CMD_SHA:-$(sha_of moca-cmd)}"
 
-# Verify repos are cloned
-if [ ! -d "$BUILD_DIR/moca" ]; then
-  echo "Error: moca repo not cloned at $BUILD_DIR/moca"
-  echo "Run: make clone"
+# docker_image <local-tag> <cache-name> <sha> [docker build args...]
+docker_image() {
+  local local_tag="$1" name="$2" sha="$3"; shift 3
+  local ref="${GHCR_REPO}-${name}:${sha}"
+  case "${IMAGE_MODE:-}" in
+    pull)
+      echo "--- pull ${ref}"
+      docker pull "$ref"
+      docker tag "$ref" "$local_tag"
+      ;;
+    cache)
+      if docker manifest inspect "$ref" >/dev/null 2>&1; then
+        echo "--- cache hit ${ref}"
+        docker pull "$ref"
+        docker tag "$ref" "$local_tag"
+      else
+        echo "--- cache miss, building ${ref}"
+        docker build -t "$local_tag" "$@"
+        docker tag "$local_tag" "$ref"
+        docker push "$ref"
+      fi
+      ;;
+    *)
+      docker build -t "$local_tag" "$@"
+      ;;
+  esac
+}
+
+echo "=== Images (mode=${IMAGE_MODE:-local}, arch=$ARCH) ==="
+
+# Shards (pull) have no cloned repos; only build/cache modes need them present.
+if [ "${IMAGE_MODE:-}" != "pull" ] && [ ! -d "$BUILD_DIR/moca" ]; then
+  echo "Error: moca repo not cloned at $BUILD_DIR/moca (run: make clone)"
   exit 1
 fi
 
-# --- Build mocad image (plain docker) ---
-echo "--- Building mocad image ---"
-docker build \
-  -t mocad-local:latest \
-  -f "$ROOT_DIR/docker/Dockerfile.mocad" \
-  --build-arg TARGETARCH="$ARCH" \
-  $TOKEN_ARG \
-  "$ROOT_DIR"
+# mocad, cosmovisor and genesis-init derive from the moca chain repo.
+docker_image mocad-local:latest mocad "$MOCA_SHA" \
+  -f "$ROOT_DIR/docker/Dockerfile.mocad" --build-arg TARGETARCH="$ARCH" $TOKEN_ARG "$ROOT_DIR"
 
-# --- Build cosmovisor image ---
-echo "--- Building cosmovisor image ---"
-docker build \
-  -t mocad-cosmovisor:latest \
-  -f "$ROOT_DIR/docker/Dockerfile.cosmovisor" \
-  --build-arg TARGETARCH="$ARCH" \
-  $TOKEN_ARG \
-  "$ROOT_DIR"
+docker_image mocad-cosmovisor:latest cosmovisor "$MOCA_SHA" \
+  -f "$ROOT_DIR/docker/Dockerfile.cosmovisor" --build-arg TARGETARCH="$ARCH" $TOKEN_ARG "$ROOT_DIR"
 
-# --- Build SP image (if cloned) ---
-if [ -d "$BUILD_DIR/moca-storage-provider" ]; then
-  echo "--- Building storage provider image ---"
-  docker build \
-    -t moca-sp-local:latest \
-    -f "$ROOT_DIR/docker/Dockerfile.sp" \
-    --build-arg TARGETARCH="$ARCH" \
-    $TOKEN_ARG \
-    "$ROOT_DIR"
-else
-  echo "Warning: moca-storage-provider not cloned, skipping SP image build"
-fi
+docker_image moca-sp-local:latest sp "$SP_SHA" \
+  -f "$ROOT_DIR/docker/Dockerfile.sp" --build-arg TARGETARCH="$ARCH" $TOKEN_ARG "$ROOT_DIR"
 
-# --- Build init image (reuses mocad-local as base) ---
-echo "--- Building genesis-init image ---"
-docker build \
-  -t moca-genesis-init:latest \
-  -f "$ROOT_DIR/docker/Dockerfile.init" \
-  "$ROOT_DIR"
+# genesis-init COPYs --from=mocad-local:latest, present in the daemon from the
+# mocad step above (built or pulled). Key it on the moca commit too.
+docker_image moca-genesis-init:latest genesis-init "$MOCA_SHA" \
+  -f "$ROOT_DIR/docker/Dockerfile.init" "$ROOT_DIR"
 
-# --- Build moca-cmd image (if cloned) ---
-if [ -d "$BUILD_DIR/moca-cmd" ]; then
-  echo "--- Building moca-cmd image ---"
-  docker build \
-    -t moca-cmd-local:latest \
-    -f "$ROOT_DIR/docker/Dockerfile.moca-cmd" \
-    --build-arg TARGETARCH="$ARCH" \
-    $TOKEN_ARG \
-    "$ROOT_DIR"
-else
-  echo "Warning: moca-cmd not cloned, skipping moca-cmd image build"
-fi
+docker_image moca-cmd-local:latest moca-cmd "$CMD_SHA" \
+  -f "$ROOT_DIR/docker/Dockerfile.moca-cmd" --build-arg TARGETARCH="$ARCH" $TOKEN_ARG "$ROOT_DIR"
 
-echo ""
-echo "=== All images built ==="
+echo "=== Images ready ==="
 docker images | grep -E "(mocad-local|mocad-cosmovisor|moca-sp-local|moca-genesis-init|moca-cmd-local)" || true

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -34,10 +34,15 @@ MOCA_SHA="${MOCA_SHA:-$(sha_of moca)}"
 SP_SHA="${SP_SHA:-$(sha_of moca-storage-provider)}"
 CMD_SHA="${CMD_SHA:-$(sha_of moca-cmd)}"
 
+# Recipe hash: the docker/ tree (Dockerfiles + entrypoints). Folding it into the
+# cache tag invalidates images when the build recipe changes, not just the source.
+# Both build and shard jobs compute it from the same checkout, so keys line up.
+RECIPE_HASH="$(git -C "$ROOT_DIR" rev-parse --short=12 HEAD:docker 2>/dev/null || echo r0)"
+
 # docker_image <local-tag> <cache-name> <sha> [docker build args...]
 docker_image() {
   local local_tag="$1" name="$2" sha="$3"; shift 3
-  local ref="${GHCR_REPO}-${name}:${sha}"
+  local ref="${GHCR_REPO}-${name}:${sha}-${RECIPE_HASH}"
   case "${IMAGE_MODE:-}" in
     pull)
       echo "--- pull ${ref}"

--- a/scripts/run-suite.sh
+++ b/scripts/run-suite.sh
@@ -41,8 +41,10 @@ else
 fi
 
 PASSED=0
+SKIPPED=0
 FAILED=0
 ERRORS=""
+SKIPS=""
 
 # Map each test to a shard group so parallel CI jobs can run disjoint subsets:
 #   chain — consensus / bank / staking / EVM (no SP dependency)
@@ -68,7 +70,23 @@ for test_file in "$TESTS_DIR"/$TEST_PATTERN; do
   echo ""
   echo "--- Running: $test_name"
 
-  if bash "$test_file" "$ENV" "$CONFIG_FILE"; then
+  # Capture output to classify a skip, while still streaming it to the log via tee.
+  out_file="$(mktemp)"
+  set +e
+  bash "$test_file" "$ENV" "$CONFIG_FILE" 2>&1 | tee "$out_file"
+  rc=${PIPESTATUS[0]}
+  set -e
+  # Last non-blank line, leading whitespace stripped — used for the SKIP marker.
+  last_line="$(grep -vE '^[[:space:]]*$' "$out_file" | tail -n 1 | sed 's/^[[:space:]]*//')"
+  rm -f "$out_file"
+
+  # SKIPPED = the reserved skip code 77 (from skip()), or exit 0 whose final line is
+  # a `SKIP:` marker (legacy inline skips). A skip is never counted as a pass.
+  if [ "$rc" -eq 77 ] || { [ "$rc" -eq 0 ] && [ "${last_line#SKIP:}" != "$last_line" ]; }; then
+    echo "  SKIP: $test_name"
+    SKIPPED=$((SKIPPED + 1))
+    SKIPS="$SKIPS\n  - $test_name"
+  elif [ "$rc" -eq 0 ]; then
     echo "  PASS: $test_name"
     PASSED=$((PASSED + 1))
   else
@@ -79,14 +97,28 @@ for test_file in "$TESTS_DIR"/$TEST_PATTERN; do
 done
 
 echo ""
-echo "=== Results: $PASSED passed, $FAILED failed ==="
+echo "=== Results: $PASSED passed, $SKIPPED skipped, $FAILED failed ==="
+[ "$SKIPPED" -gt 0 ] && echo -e "Skipped tests:$SKIPS"
 
-if [ $FAILED -gt 0 ]; then
+if [ "$FAILED" -gt 0 ]; then
   echo -e "Failed tests:$ERRORS"
   exit 1
 fi
 
-if [ $PASSED -eq 0 ]; then
+# A shard that matched no tests is a misconfiguration (bad/renamed TEST_GROUP),
+# not a pass — otherwise an empty shard would go green having run nothing.
+if [ $((PASSED + SKIPPED)) -eq 0 ]; then
+  if [ -n "${TEST_GROUP:-}" ]; then
+    echo "Error: shard TEST_GROUP='$TEST_GROUP' matched no tests"
+    exit 1
+  fi
   echo "Warning: no tests found matching pattern '$TEST_PATTERN' in $TESTS_DIR"
   exit 0
+fi
+
+# Strict mode (CI shards): a skip means a precondition that should hold in the
+# controlled cluster didn't, so fail loudly instead of passing green with a gap.
+if [ "${STRICT_SKIPS:-0}" = "1" ] && [ "$SKIPPED" -gt 0 ]; then
+  echo "Error: STRICT_SKIPS=1 and $SKIPPED test(s) skipped:$SKIPS"
+  exit 1
 fi

--- a/scripts/run-suite.sh
+++ b/scripts/run-suite.sh
@@ -44,11 +44,27 @@ PASSED=0
 FAILED=0
 ERRORS=""
 
+# Map each test to a shard group so parallel CI jobs can run disjoint subsets:
+#   chain — consensus / bank / staking / EVM (no SP dependency)
+#   sp    — SP registration, config, lifecycle (incl. sp-exit)
+#   flows — storage / payment / virtualgroup / object-failover (also any new test)
+group_of() {
+  case "$1" in
+    smoke_sp_status.sh|test_sp_*) echo sp ;;
+    smoke_chain_status.sh|smoke_validator_set.sh|test_bank_*|test_block_*|test_cross_*|test_staking*|test_validator_*|test_evm_*) echo chain ;;
+    *) echo flows ;;
+  esac
+}
+
 for test_file in "$TESTS_DIR"/$TEST_PATTERN; do
   [ -f "$test_file" ] || continue
   test_name=$(basename "$test_file")
   # Skip helper libraries
   [ "$test_name" = "lib.sh" ] && continue
+  # Shard filter: when TEST_GROUP is set, run only that group's tests (parallel CI).
+  if [ -n "${TEST_GROUP:-}" ] && [ "$(group_of "$test_name")" != "$TEST_GROUP" ]; then
+    continue
+  fi
   echo ""
   echo "--- Running: $test_name"
 

--- a/tests/libs/core.sh
+++ b/tests/libs/core.sh
@@ -30,15 +30,21 @@ writes_allowed() {
   [ "${ENV:-local}" = "local" ] || [ "${ALLOW_WRITES:-0}" = "1" ] || [ "${E2E_ALLOW_WRITES:-0}" = "1" ]
 }
 
+# skip <reason>: mark the current test as skipped (distinct from a pass) and stop.
+# run-suite classifies exit code 77 as SKIPPED, so a skipped test is never counted
+# as a pass. Prefer this over `echo "SKIP: ..."; exit 0` in new tests.
+skip() {
+  echo "SKIP: $*"
+  exit 77
+}
+
 require_write_enabled() {
   local test_name="${1:-write test}"
   if [ "${ENV:-}" = "mainnet" ]; then
-    echo "SKIP: not safe for mainnet"
-    exit 0
+    skip "not safe for mainnet"
   fi
   if ! writes_allowed; then
-    echo "SKIP: ${test_name} requires writes; set ALLOW_WRITES=1 to enable on ${ENV:-unknown}"
-    exit 0
+    skip "${test_name} requires writes; set ALLOW_WRITES=1 to enable on ${ENV:-unknown}"
   fi
 }
 
@@ -104,14 +110,12 @@ get_key_address() {
 
 require_test_key() {
   if [ -z "$TEST_KEY" ]; then
-    echo "SKIP: no test key configured (set DEVNET_TEST_KEY=<keyname> for devnet)"
-    exit 0
+    skip "no test key configured (set DEVNET_TEST_KEY=<keyname> for devnet)"
   fi
   local addr
   addr=$(get_key_address "$TEST_KEY")
   if [ -z "$addr" ]; then
-    echo "SKIP: test key '$TEST_KEY' not found in keyring"
-    exit 0
+    skip "test key '$TEST_KEY' not found in keyring"
   fi
   # On remote envs, check the account has enough funds (~3 MOCA minimum for full suite)
   if [ "${ENV:-local}" != "local" ]; then


### PR DESCRIPTION
Stacked on #58. Optimizes e2e wall-clock/compute.

## What
- **`build` job**: builds the 5 component images **once** and caches them in this repo's GHCR (`ghcr.io/<owner>/moca-e2e-<name>:<component-sha>`). Unchanged components are **pulled, not rebuilt** across runs. Outputs the resolved component SHAs.
- **`e2e` matrix [chain | sp | flows]**: each shard **pulls** the prebuilt images (no rebuild, no clone) and runs only its test group on its own 9-SP cluster, in parallel (`fail-fast: false`).
- `run-suite.sh`: `TEST_GROUP` selects a shard's tests via `group_of()`.
- `build.sh`: `IMAGE_MODE=cache|pull` (registry) vs unset (plain `docker build` locally/test-box).

## Cache is entirely in moca-e2e
Images live in this repo's GHCR namespace, authed with `GITHUB_TOKEN` — no reliance on moca / moca-cmd / SP repos to hold any cache.

## Expected wall-clock
- Same-stack re-runs: all cache hits → build job ~2-3 min + slowest shard → ~12-14 min.
- Rolling update (a component changed): that image rebuilds on the build job's critical path, then shards → ~18-22 min.
- 1× build compute (shards don't rebuild).

Failover runs in `flows` on a fresh 9-SP cluster (no sp-exit there), so it doesn't skip.

Note: GHCR push/matrix are CI-only — will iterate here. Retarget to `main` once #58 lands.

Generated with Claude Code
