### PR TITLE
chore(stack): pin the rc0 release matrix

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -5,13 +5,13 @@
 components:
   moca:
     repo: mocachain/moca
-    ref: 3aa08c07947f23d4f9cd7bfbce3bbb9e0f8a66a4
+    ref: v2.0.0-rc0
   moca-storage-provider:
     repo: mocachain/moca-storage-provider
-    ref: 2cb51af59081076bc4ef16122941070816c76e0e
+    ref: v1.3.0-rc0
   moca-cmd:
     repo: mocachain/moca-cmd
-    ref: cbe5b3ccec68162295818da2ee534c23f491af21
+    ref: v1.3.0-rc0
   moca-juno:
     repo: mocachain/moca-juno
     ref: 74e124b2bd80ebaf067c19d6fd293a0bb5b0e8d7


### PR DESCRIPTION
## What
Sets the known-good stack pointer to the coordinated rc tag set:
- `moca` → **v2.0.0-rc0** (commit 9ff8aa31)
- `moca-storage-provider` → **v1.3.0-rc0** (commit 1df15ec3)
- `moca-cmd` → **v1.3.0-rc0** (commit bbad0b1a)
- `moca-juno` unchanged (pinned commit, pending the juno→v2 migration in moca-juno#13)

Tag refs resolve fine in clone-repos.sh. The merged commit is the release's compatibility manifest; subsequent repository_dispatch updates will resume overwriting refs with SHAs — normal rolling behavior.

## Why
The rolling automation records one component per dispatch and rebuilds from main each time — moca's 13:49Z update was clobbered by SP's later dispatch, and moca-cmd has no notify-e2e.yml, so the rolling PR (#62) can't capture the coordinated release. This PR records the full rc0 matrix in one commit; the green e2e run is the compatibility proof.

Housekeeping noted separately: moca-cmd lacks notify-e2e.yml (copy from notify-template/) — its merges never advance the pointer.
