### PR TITLE
fix(ci): build images on golang:1.25-bookworm (unblocks stack update)

### DIFF
--- a/docker/Dockerfile.cosmovisor
+++ b/docker/Dockerfile.cosmovisor
@@ -2,7 +2,7 @@
 # recompiled) plus the cosmovisor supervisor. build.sh builds/pulls mocad first, so
 # mocad-local:latest is present in the daemon. This avoids a second full ~10-min moca
 # compile whenever the moca commit changes.
-FROM golang:1.23-bullseye AS builder
+FROM golang:1.25-bookworm AS builder
 
 # Declared for build-arg compatibility with build.sh; unused here (no moca compile).
 ARG TARGETARCH
@@ -10,7 +10,7 @@ ARG GITHUB_TOKEN=""
 
 RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@latest
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl jq \

--- a/docker/Dockerfile.init
+++ b/docker/Dockerfile.init
@@ -1,6 +1,6 @@
 # Genesis init container — generates keys, genesis, and validator/SP configs.
 # Writes everything to /output which is a shared volume.
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl jq bash \

--- a/docker/Dockerfile.moca-cmd
+++ b/docker/Dockerfile.moca-cmd
@@ -1,4 +1,4 @@
-FROM golang:1.23-bullseye AS builder
+FROM golang:1.25-bookworm AS builder
 
 ARG TARGETARCH
 ARG GITHUB_TOKEN=""
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     GOARCH=${TARGETARCH} \
     make build
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl jq \

--- a/docker/Dockerfile.mocad
+++ b/docker/Dockerfile.mocad
@@ -1,4 +1,4 @@
-FROM golang:1.23-bullseye AS builder
+FROM golang:1.25-bookworm AS builder
 
 ARG TARGETARCH
 ARG GITHUB_TOKEN=""
@@ -20,7 +20,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     GOARCH=${TARGETARCH} \
     make build
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl jq \

--- a/docker/Dockerfile.sp
+++ b/docker/Dockerfile.sp
@@ -1,4 +1,4 @@
-FROM golang:1.23-bullseye AS builder
+FROM golang:1.25-bookworm AS builder
 
 ARG TARGETARCH
 ARG GITHUB_TOKEN=""
@@ -18,7 +18,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     GOARCH=${TARGETARCH} \
     make build
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl jq default-mysql-client \


### PR DESCRIPTION
## Problem
The rolling stack-update (#62, SP bump to `1df15ec`) fails at the SP image build:
```
go: go.mod requires go >= 1.25.8 (running go 1.23.12; GOTOOLCHAIN=local)
build failed Ooooooh!!!
```
The SP migrated to **go 1.25.8** and its Makefile pins `GOTOOLCHAIN=local`, so the builder's local Go must be ≥ 1.25.8 — but every moca-e2e Dockerfile builds on `golang:1.23`. (mocad only survived because moca's build auto-downloads the toolchain; the SP's `local` pin blocks that.)

## Fix
Bump all 5 Dockerfiles' builders to `golang:1.25-bookworm` and runtimes to `debian:bookworm-slim`. `golang:1.25` has no `-bullseye` variant (bullseye is EOL), so the runtime moves to bookworm to keep the CGO/BLST binaries' glibc matched with the builder.

Bumping all (not just SP) keeps the images consistent and stops this recurring as each component migrates to 1.25.8.

Note: the SP repo's *own* `Dockerfile` is also still on `golang:1.23.6` — worth fixing upstream, but out of scope here.

Generated with Claude Code
