### PR TITLE
fix(sp): provision internal gRPC mTLS + bump stack pins to latest mains

### DIFF
--- a/docker/Dockerfile.sp
+++ b/docker/Dockerfile.sp
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates curl jq default-mysql-client \
+    ca-certificates curl jq default-mysql-client openssl \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /build/build/moca-sp /usr/local/bin/moca-sp

--- a/docker/entrypoint-sp.sh
+++ b/docker/entrypoint-sp.sh
@@ -77,6 +77,36 @@ fi
 DSN_SPDB="${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/${DB_NAME}?parseTime=true&multiStatements=true&loc=Local"
 DSN_BSDB="${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/${BS_DB_NAME}?parseTime=true&multiStatements=true&loc=Local"
 
+# Patch config: internal gRPC mTLS. moca-sp requires [GRPCTLS] CA/cert/key at
+# startup and the signer only accepts client certs whose SPIFFE URI is in
+# [SignerAuth] AllowedClientURIs. All modules run in-process here, so a
+# per-container throwaway CA with the SP's own identity is sufficient. SANs
+# cover 127.0.0.1 and localhost because clients verify the dial host and the
+# tests dial --endpoint localhost:9333.
+TLS_DIR="$SP_HOME/grpc-tls"
+SPIFFE_ID="spiffe://mocachain.local/${SP_NAME}"
+mkdir -p "$TLS_DIR"
+openssl req -x509 -newkey rsa:2048 -nodes -days 2 \
+  -keyout "$TLS_DIR/ca.key" -out "$TLS_DIR/ca.crt" \
+  -subj "/CN=moca-e2e ${SP_NAME} CA" >/dev/null 2>&1
+openssl req -newkey rsa:2048 -nodes \
+  -keyout "$TLS_DIR/tls.key" -out "$TLS_DIR/tls.csr" \
+  -subj "/CN=${SP_NAME}" >/dev/null 2>&1
+{
+  echo "subjectAltName=IP:127.0.0.1,DNS:localhost,URI:${SPIFFE_ID}"
+  echo "extendedKeyUsage=serverAuth,clientAuth"
+} > "$TLS_DIR/tls.ext"
+openssl x509 -req -in "$TLS_DIR/tls.csr" \
+  -CA "$TLS_DIR/ca.crt" -CAkey "$TLS_DIR/ca.key" -CAcreateserial \
+  -out "$TLS_DIR/tls.crt" -days 2 -extfile "$TLS_DIR/tls.ext" >/dev/null 2>&1
+rm -f "$TLS_DIR/tls.csr" "$TLS_DIR/tls.ext"
+chmod 600 "$TLS_DIR/ca.key" "$TLS_DIR/tls.key"
+sed -i "s|^GRPCAddress = '.*'|GRPCAddress = '127.0.0.1:9333'|" config.toml
+sed -i "s|^CACertFile = '.*'|CACertFile = '${TLS_DIR}/ca.crt'|" config.toml
+sed -i "s|^CertFile = '.*'|CertFile = '${TLS_DIR}/tls.crt'|" config.toml
+sed -i "s|^KeyFile = '.*'|KeyFile = '${TLS_DIR}/tls.key'|" config.toml
+sed -i "s|^AllowedClientURIs = \[.*\]|AllowedClientURIs = ['${SPIFFE_ID}']|" config.toml
+
 # Patch config: Chain
 sed -i "s|ChainID = '.*'|ChainID = '${CHAIN_ID}'|g" config.toml
 sed -i "s|ChainAddress = \[.*\]|ChainAddress = ['http://${RPC_HOST}:${RPC_PORT}']|g" config.toml

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,13 +8,13 @@ components:
     ref: cc51485370bc15d627fa4c5caba312417189ad52
   moca-storage-provider:
     repo: mocachain/moca-storage-provider
-    ref: 2cb51af59081076bc4ef16122941070816c76e0e
+    ref: e4cd1930f0b62ad55e87fb8dd2e028b01fee5f9d
   moca-cmd:
     repo: mocachain/moca-cmd
-    ref: cbe5b3ccec68162295818da2ee534c23f491af21
+    ref: bbad0b1a51cc450286205fc9a67f2ab6bc1ff9a2
   moca-juno:
     repo: mocachain/moca-juno
-    ref: 74e124b2bd80ebaf067c19d6fd293a0bb5b0e8d7
+    ref: 073d9e539a147f12274e2a23163aeb3295ffdb27
   moca-common:
     repo: mocachain/moca-common
     ref: main


### PR DESCRIPTION
## Why

The rolling stack PR (#65) is red on all three shards: every SP crash-loops at boot with `GRPCTLS.CACertFile is required`, so the stack never becomes healthy and the shards time out (exit 124) before running a single test.

Cause: bumping moca-storage-provider to main HEAD `e4cd1930` picks up SP [#63](https://github.com/mocachain/moca-storage-provider/pull/63) (mandatory mutual TLS 1.3 on all internal gRPC, no insecure fallback) and [#62](https://github.com/mocachain/moca-storage-provider/pull/62) (signer rejects clients whose SPIFFE URI isn't allowlisted). The e2e SP entrypoint (`config.dump` + sed) provisioned neither.

That same pin also carries SP [#60](https://github.com/mocachain/moca-storage-provider/pull/60) — the bsdb private-batch-lookup fix that unblocks the `test_sp_exit` GVG-migration stall that has kept the rolling PR red since 07-22.

## What

- **docker/entrypoint-sp.sh**: generate a per-container throwaway CA + leaf cert at boot (SANs `IP:127.0.0.1, DNS:localhost, URI:spiffe://mocachain.local/<sp-name>`, EKU serverAuth+clientAuth — mirrors SP's own `deployment/localup/generate_grpc_tls.sh`), patch `[GRPCTLS]` paths, `[SignerAuth] AllowedClientURIs` (all-in-one: the SP's own identity is the only signer client), and `GRPCAddress = 127.0.0.1:9333` (clients verify the dial host against cert SANs; `DNS:localhost` keeps the tests' explicit `--endpoint localhost:9333` working). SP CLI invocations in tests read the same config.toml, so they get TLS for free.
- **docker/Dockerfile.sp**: add `openssl` to the runtime image.
- **stack.yaml**: SP `2cb51af5` → `e4cd1930`, moca-cmd `cbe5b3cc` → `bbad0b1a`, moca-juno `74e124b2` → `073d9e53` (moca already at main HEAD `cc514853`; floating `main` refs unchanged).

Manual stack PR because the rolling bot advances one component per green run, and the SP bump cannot go green without the entrypoint change — they have to land together.

## Validation

Full suite run on a clean amd64 box against exactly these pins + this entrypoint: **26 PASS, 0 FAIL**, including `test_sp_exit` (complete SP exit with GVG migration — red since 07-22, now green, confirming SP #60) and `test_sp_exit_empty_family_blocker`. All 9 SPs healthy with 0 restarts and no TLS errors. One SKIP: `test_storage_object_failover` — single-stack ordering artifact (sp-0 had already fully exited in the same stack); CI's sharded fresh stacks don't hit it.
