### PR TITLE
fix(tests): remove false-pass branches — failures must fail

### DIFF
--- a/scripts/generate-compose.sh
+++ b/scripts/generate-compose.sh
@@ -29,6 +29,7 @@ EVM_WS_BASE=$(yq '.ports.evm_ws_base' "$TOPOLOGY")
 P2P_BASE=$(yq '.ports.p2p_base' "$TOPOLOGY")
 SP_GW_BASE=$(yq '.ports.sp_gateway_base' "$TOPOLOGY")
 SP_P2P_BASE=$(yq '.ports.sp_p2p_base' "$TOPOLOGY")
+SP_PROBE_BASE=$(yq '.ports.sp_probe_base // 9502' "$TOPOLOGY")
 
 # Count validators and SPs
 NUM_VALIDATORS=$(yq '.validators | length' "$TOPOLOGY")
@@ -153,6 +154,7 @@ for i in $(seq 0 $((NUM_SPS - 1))); do
   NAME=$(yq ".storage_providers[$i].name" "$TOPOLOGY")
   GW_PORT=$((SP_GW_BASE + i))
   P2P_PORT=$((SP_P2P_BASE + i * 100))
+  PROBE_PORT=$((SP_PROBE_BASE + i))
 
   cat >> "$OUTPUT" <<SP
   # === Storage Provider $i ===
@@ -177,6 +179,7 @@ for i in $(seq 0 $((NUM_SPS - 1))); do
     ports:
       - "${GW_PORT}:9033"
       - "${P2P_PORT}:9400"
+      - "${PROBE_PORT}:9402"
     depends_on:
       mysql:
         condition: service_healthy

--- a/tests/smoke_sp_status.sh
+++ b/tests/smoke_sp_status.sh
@@ -14,19 +14,16 @@ fi
 echo "Checking storage providers at $REST..."
 
 # Query storage providers from the SP module
-RESPONSE=$(curl -sf "${REST}/greenfield/sp/storage_providers" 2>/dev/null) || {
-  # Fallback: try alternate endpoint
-  RESPONSE=$(curl -sf "${REST}/mocachain/storage/providers" 2>/dev/null) || {
-    echo "WARN: Cannot query storage providers (endpoint may not exist yet)"
-    exit 0
-  }
+RESPONSE=$(curl -sf "${REST}/moca/storage_providers" 2>/dev/null) || {
+  echo "FAIL: cannot query storage providers via REST"
+  exit 1
 }
 
-NUM_SPS=$(echo "$RESPONSE" | jq '.sps | length // .storage_providers | length // 0')
+NUM_SPS=$(echo "$RESPONSE" | jq '.sps | length // 0')
 
 if [ "$NUM_SPS" -le 0 ]; then
-  echo "WARN: No storage providers found on chain"
-  exit 0
+  echo "FAIL: no storage providers found on chain"
+  exit 1
 fi
 
 echo "PASS: $NUM_SPS storage providers registered on chain"

--- a/tests/test_evm_erc20.sh
+++ b/tests/test_evm_erc20.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# E2E test: deploy and interact with ERC20 contract
+# E2E test: deploy a contract and interact with it (Store: set/get)
 # shellcheck shell=bash source-path=SCRIPTDIR
 set -euo pipefail
 
@@ -16,7 +16,7 @@ if ! command -v cast &>/dev/null; then
   exit 0
 fi
 
-echo "Testing ERC20 deploy and transfer..."
+echo "Testing EVM contract deploy and interaction..."
 
 # Get test private key
 PRIVKEY=$(docker exec "$VALIDATOR_CONTAINER" cat /shared/metadata.json 2>/dev/null | jq -r '.test_account.evm_privkey // empty' 2>/dev/null || echo "")
@@ -29,36 +29,34 @@ fi
 SENDER=$(cast wallet address "0x${PRIVKEY}" 2>/dev/null)
 echo "  Deployer: $SENDER"
 
-# Minimal ERC20 bytecode (OpenZeppelin ERC20 with constructor mint)
-# This is a pre-compiled simple token: constructor(string name, string symbol) mints 1M to deployer
-# Using a minimal proxy pattern instead — deploy raw bytecode for a simple storage contract
-# to verify EVM execution works
-#
-# Simple contract: stores a value and retrieves it
-# contract Store { uint256 public value; function set(uint256 v) public { value = v; } }
-STORE_BYTECODE="0x608060405234801561001057600080fd5b5060e68061001f6000396000f3fe6080604052348015600f57600080fd5b506004361060325760003560e01c806360fe47b11460375780636d4ce63c14604f575b600080fd5b604d60048036038101906049919060a0565b6065565b005b6055606f565b604051606091906096565b60405180910390f35b8060008190555050565b60008054905090565b600081359050609a8160c7565b92915050565b60006020828403121560b15760b060c2565b5b600060bd848285016089565b91505092915050565b600080fd5b6000819050919050565b60d08160cb565b811460da57600080fd5b5056fea2646970667358221220"
+# Store contract, solc 0.8.26, optimizer runs=200, cbor_metadata=false,
+# bytecode_hash=none (deterministic, no metadata tail):
+#   contract Store {
+#       uint256 private value;
+#       function set(uint256 v) public { value = v; }
+#       function get() public view returns (uint256) { return value; }
+#   }
+STORE_BYTECODE="0x6080604052348015600e575f80fd5b50606f80601a5f395ff3fe6080604052348015600e575f80fd5b50600436106030575f3560e01c806360fe47b11460345780636d4ce63c146045575b5f80fd5b6043603f3660046059565b5f55565b005b5f5460405190815260200160405180910390f35b5f602082840312156068575f80fd5b503591905056"
 
-# Deploy contract
+# Deploy contract. Flags must precede --create: cast parses everything after
+# the bytecode as constructor SIG/ARGS.
 echo "  Deploying storage contract..."
-DEPLOY_OUTPUT=$(cast send --create "$STORE_BYTECODE" \
-  --private-key "0x${PRIVKEY}" --rpc-url "$EVM_RPC" \
-  --chain-id "$EVM_CHAIN_ID" --json 2>/dev/null) || {
-  echo "  WARN: Contract deployment failed"
-  echo "PASS: EVM execution tested (deployment attempted)"
-  exit 0
+DEPLOY_OUTPUT=$(cast send --private-key "0x${PRIVKEY}" --rpc-url "$EVM_RPC" \
+  --chain-id "$EVM_CHAIN_ID" --json \
+  --create "$STORE_BYTECODE" 2>&1) || {
+  echo "  FAIL: contract deployment failed: $DEPLOY_OUTPUT"
+  exit 1
 }
 
 TX_HASH=$(echo "$DEPLOY_OUTPUT" | jq -r '.transactionHash // empty' 2>/dev/null)
 if [ -z "$TX_HASH" ]; then
-  echo "  WARN: No tx hash from deployment"
-  echo "PASS: EVM execution tested"
-  exit 0
+  echo "  FAIL: no tx hash from deployment: $DEPLOY_OUTPUT"
+  exit 1
 fi
 
 wait_for_evm_tx "$TX_HASH" 10 || {
-  echo "  WARN: deploy tx $TX_HASH did not mine within 10s"
-  echo "PASS: EVM execution tested (deploy submitted)"
-  exit 0
+  echo "  FAIL: deploy tx $TX_HASH did not mine within 10s"
+  exit 1
 }
 
 # Get contract address from receipt
@@ -66,9 +64,8 @@ RECEIPT=$(cast receipt "$TX_HASH" --rpc-url "$EVM_RPC" --json 2>/dev/null)
 CONTRACT=$(echo "$RECEIPT" | jq -r '.contractAddress // empty' 2>/dev/null)
 
 if [ -z "$CONTRACT" ] || [ "$CONTRACT" = "null" ]; then
-  echo "  WARN: No contract address in receipt"
-  echo "PASS: EVM tx submitted successfully"
-  exit 0
+  echo "  FAIL: no contract address in receipt: $RECEIPT"
+  exit 1
 fi
 
 echo "  Contract deployed at: $CONTRACT"
@@ -86,20 +83,25 @@ echo "  Calling set(42)..."
 SET_OUT=$(cast send "$CONTRACT" "set(uint256)" 42 \
   --private-key "0x${PRIVKEY}" --rpc-url "$EVM_RPC" \
   --chain-id "$EVM_CHAIN_ID" --json 2>&1) || {
-  echo "  WARN: set(42) broadcast failed: $SET_OUT"
-  echo "PASS: EVM contract deployed (set call failed)"
-  exit 0
+  echo "  FAIL: set(42) broadcast failed: $SET_OUT"
+  exit 1
 }
 SET_HASH=$(echo "$SET_OUT" | jq -r '.transactionHash // empty' 2>/dev/null)
-[ -n "$SET_HASH" ] && wait_for_evm_tx "$SET_HASH" 10
+if [ -z "$SET_HASH" ]; then
+  echo "  FAIL: set(42) returned no tx hash: $SET_OUT"
+  exit 1
+fi
+wait_for_evm_tx "$SET_HASH" 10 || {
+  echo "  FAIL: set tx $SET_HASH not mined within 10s"
+  exit 1
+}
 
 # Call get() and verify
 VALUE=$(cast call "$CONTRACT" "get()(uint256)" --rpc-url "$EVM_RPC" 2>/dev/null || echo "")
 echo "  get() returned: $VALUE"
 
-if [ "$VALUE" = "42" ]; then
-  echo "PASS: EVM contract deploy + interact successful"
-else
-  echo "  WARN: get() returned '$VALUE' (expected 42)"
-  echo "PASS: EVM contract deployed and code verified"
+if [ "$VALUE" != "42" ]; then
+  echo "  FAIL: get() returned '$VALUE' (expected 42)"
+  exit 1
 fi
+echo "PASS: EVM contract deploy + interact successful"

--- a/tests/test_evm_transfer.sh
+++ b/tests/test_evm_transfer.sh
@@ -78,8 +78,8 @@ BALANCE_AFTER=$(curl -sf "$EVM_RPC" -X POST -H "Content-Type: application/json" 
 echo "  Recipient balance after: $BALANCE_AFTER"
 
 assert_ne "$BALANCE_AFTER" "$BALANCE_BEFORE" "EVM balance changed" || {
-  echo "  WARN: Balance didn't change"
-  exit 0
+  echo "  FAIL: recipient balance did not change after mined transfer"
+  exit 1
 }
 
 echo "PASS: Native EVM transfer successful"

--- a/tests/test_payment.sh
+++ b/tests/test_payment.sh
@@ -22,7 +22,7 @@ OWNER_ADDR=$(exec_mocad keys show "$TEST_KEY" -a --keyring-backend test 2>/dev/n
 run_moca_cmd_payment() {
   echo "Testing payment module (moca-cmd path)..."
 
-  local default_addr out pa_addr before bal dep_amt after withdraw_amt after2
+  local default_addr out pa_addr before dep_amt after withdraw_amt after2
   default_addr="$(exec_moca_cmd account ls 2>/dev/null | grep -oE '0x[a-fA-F0-9]{40}' | head -1 || true)"
   if [ -z "$default_addr" ]; then
     default_addr="$OWNER_ADDR"
@@ -66,6 +66,10 @@ run_moca_cmd_payment() {
   out=$(exec_moca_cmd payment-account stream-record "$pa_addr" || true)
   after=$(echo "$out" | grep -oE 'Static Balance:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | head -1 || echo "0")
   echo "  static balance after deposit: $after (before: $before)"
+  if [ "${after:-0}" -le "${before:-0}" ]; then
+    echo "FAIL: static balance did not increase after deposit"
+    exit 1
+  fi
 
   withdraw_amt="500000000000000000"
   print_test_section "withdraw"
@@ -76,6 +80,10 @@ run_moca_cmd_payment() {
   out=$(exec_moca_cmd payment-account stream-record "$pa_addr" || true)
   after2=$(echo "$out" | grep -oE 'Static Balance:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | head -1 || echo "0")
   echo "  static balance after withdraw: $after2"
+  if [ "${after2:-0}" -ge "${after:-0}" ]; then
+    echo "FAIL: static balance did not decrease after withdraw"
+    exit 1
+  fi
 
   exec_moca_cmd payment-account ls --owner "$default_addr" 2>/dev/null | head -8 || true
   echo "PASS: payment module (moca-cmd path)"
@@ -94,15 +102,14 @@ run_mocad_payment() {
     -y 2>/dev/null || echo "FAILED")
 
   if echo "$CREATE_RESULT" | grep -q "FAILED\|Error\|error"; then
-    echo "  WARN: payment account creation failed"
-    echo "PASS: payment module tested (creation attempted)"
-    exit 0
+    echo "  FAIL: payment account creation failed: $CREATE_RESULT"
+    exit 1
   fi
   wait_for_tx 5
 
   if [ -z "$OWNER_ADDR" ]; then
-    echo "PASS: payment create ok (no owner for list)"
-    exit 0
+    echo "  FAIL: cannot resolve owner address to verify created account"
+    exit 1
   fi
 
   ACCOUNTS=$(exec_mocad query payment get-payment-accounts-by-owner "$OWNER_ADDR" \
@@ -111,8 +118,8 @@ run_mocad_payment() {
   echo "  payment accounts for owner: $NUM_ACCOUNTS"
 
   if [ "$NUM_ACCOUNTS" -le 0 ]; then
-    echo "PASS: payment module tested"
-    exit 0
+    echo "  FAIL: created payment account not returned by get-payment-accounts-by-owner"
+    exit 1
   fi
 
   PA_ADDR=$(echo "$ACCOUNTS" | jq -r '.payment_accounts[0]' 2>/dev/null)
@@ -132,13 +139,20 @@ run_mocad_payment() {
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
     --gas auto --gas-adjustment 1.5 \
-    -y 2>/dev/null || echo "  WARN: deposit may have failed"
+    -y 2>/dev/null || {
+    echo "  FAIL: deposit tx broadcast failed"
+    exit 1
+  }
   wait_for_tx 5
 
   STREAM_AFTER=$(exec_mocad query payment stream-record "$PA_ADDR" \
     --node "$TM_RPC" --output json 2>/dev/null || echo "")
   BALANCE_AFTER=$(echo "$STREAM_AFTER" | jq -r '.stream_record.static_balance // "0"' 2>/dev/null)
-  echo "  stream balance after deposit: $BALANCE_AFTER"
+  echo "  stream balance after deposit: $BALANCE_AFTER (before: $BALANCE)"
+  if [ "${BALANCE_AFTER:-0}" -le "${BALANCE:-0}" ]; then
+    echo "  FAIL: static balance did not increase after deposit"
+    exit 1
+  fi
 
   WITHDRAW_AMOUNT="500000000000000000"
   exec_mocad tx payment withdraw "$PA_ADDR" "${WITHDRAW_AMOUNT}" \
@@ -147,8 +161,20 @@ run_mocad_payment() {
     --chain-id "$CHAIN_ID" \
     --node "$TM_RPC" \
     --gas auto --gas-adjustment 1.5 \
-    -y 2>/dev/null || echo "  WARN: withdraw may have failed"
+    -y 2>/dev/null || {
+    echo "  FAIL: withdraw tx broadcast failed"
+    exit 1
+  }
   wait_for_tx 3
+
+  STREAM_FINAL=$(exec_mocad query payment stream-record "$PA_ADDR" \
+    --node "$TM_RPC" --output json 2>/dev/null || echo "")
+  BALANCE_FINAL=$(echo "$STREAM_FINAL" | jq -r '.stream_record.static_balance // "0"' 2>/dev/null)
+  echo "  stream balance after withdraw: $BALANCE_FINAL"
+  if [ "${BALANCE_FINAL:-0}" -ge "${BALANCE_AFTER:-0}" ]; then
+    echo "  FAIL: static balance did not decrease after withdraw"
+    exit 1
+  fi
 
   echo "PASS: payment module operations tested (mocad path)"
 }

--- a/tests/test_sp_diagnose.sh
+++ b/tests/test_sp_diagnose.sh
@@ -75,6 +75,6 @@ echo "  responsive gateway ports: $GATEWAY_OK"
 if [ "$CNT" -gt 0 ] && { [ -n "$RUNNING_SP" ] || [ "$GATEWAY_OK" -gt 0 ]; }; then
   echo "PASS: SP diagnosis checks completed"
 else
-  echo "WARN: limited SP visibility"
-  exit 0
+  echo "FAIL: no SP visibility (on-chain count: $CNT, containers: ${RUNNING_SP:-none}, gateways ok: $GATEWAY_OK)"
+  exit 1
 fi

--- a/tests/test_sp_gateway.sh
+++ b/tests/test_sp_gateway.sh
@@ -21,25 +21,34 @@ if [ "$ENV" = "local" ]; then
   # Local: probe every sp-N container the stack defines (docker ps -a, so a
   # stopped SP fails instead of shrinking the denominator). curl -w prints 000
   # itself on connect failure, so a ||-appended fallback would yield "000000"
-  # and count dead gateways as reachable.
+  # and count dead gateways as reachable. Health/ready live on the probe
+  # server (container port 9402, host SP_PROBE_BASE+i), not the gater; both
+  # return empty bodies, so assert HTTP codes. Bases match topology defaults.
   SP_GW_BASE=9033
+  SP_PROBE_BASE=9502
   ALL_SPS=$(docker ps -a --format '{{.Names}}' 2>/dev/null | grep -E '^sp-[0-9]+$' | sort -t- -k2 -n)
   for name in $ALL_SPS; do
     i=${name#sp-}
     PORT=$((SP_GW_BASE + i))
-    URL="http://localhost:${PORT}"
+    PROBE=$((SP_PROBE_BASE + i))
     CHECKED=$((CHECKED + 1))
     if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -qx "$name"; then
       echo "  SP $i (localhost:$PORT): container not running"
       FAILED=$((FAILED + 1))
       continue
     fi
-    STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 3 "${URL}/status" 2>/dev/null || true)
+    STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 3 "http://localhost:${PORT}/status" 2>/dev/null || true)
     STATUS_CODE="${STATUS_CODE:-000}"
-    HEALTH=$(curl -sf --connect-timeout 3 "${URL}/-/healthy" 2>/dev/null || echo "")
-    READY=$(curl -sf --connect-timeout 3 "${URL}/-/ready" 2>/dev/null || echo "")
-    echo "  SP $i (localhost:$PORT): status_code=$STATUS_CODE health=${HEALTH:-N/A} ready=${READY:-N/A}"
-    [ "$STATUS_CODE" != "000" ] && PASSED=$((PASSED + 1)) || FAILED=$((FAILED + 1))
+    HEALTH_CODE=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 3 "http://localhost:${PROBE}/-/healthy" 2>/dev/null || true)
+    HEALTH_CODE="${HEALTH_CODE:-000}"
+    READY_CODE=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 3 "http://localhost:${PROBE}/-/ready" 2>/dev/null || true)
+    READY_CODE="${READY_CODE:-000}"
+    echo "  SP $i (gw localhost:$PORT probe localhost:$PROBE): status_code=$STATUS_CODE healthy=$HEALTH_CODE ready=$READY_CODE"
+    if [ "$STATUS_CODE" != "000" ] && [ "$HEALTH_CODE" = "200" ] && [ "$READY_CODE" = "200" ]; then
+      PASSED=$((PASSED + 1))
+    else
+      FAILED=$((FAILED + 1))
+    fi
   done
 else
   # Remote: get endpoints from chain and probe them

--- a/tests/test_sp_gateway.sh
+++ b/tests/test_sp_gateway.sh
@@ -18,16 +18,24 @@ FAILED=0
 CHECKED=0
 
 if [ "$ENV" = "local" ]; then
-  # Local: probe localhost ports
+  # Local: probe every sp-N container the stack defines (docker ps -a, so a
+  # stopped SP fails instead of shrinking the denominator). curl -w prints 000
+  # itself on connect failure, so a ||-appended fallback would yield "000000"
+  # and count dead gateways as reachable.
   SP_GW_BASE=9033
-  for i in 0 1 2 3 4 5; do
+  ALL_SPS=$(docker ps -a --format '{{.Names}}' 2>/dev/null | grep -E '^sp-[0-9]+$' | sort -t- -k2 -n)
+  for name in $ALL_SPS; do
+    i=${name#sp-}
     PORT=$((SP_GW_BASE + i))
     URL="http://localhost:${PORT}"
-    if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -q "sp-${i}"; then
+    CHECKED=$((CHECKED + 1))
+    if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -qx "$name"; then
+      echo "  SP $i (localhost:$PORT): container not running"
+      FAILED=$((FAILED + 1))
       continue
     fi
-    CHECKED=$((CHECKED + 1))
-    STATUS_CODE=$(curl -sf -o /dev/null -w "%{http_code}" --connect-timeout 3 "${URL}/status" 2>/dev/null || echo "000")
+    STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 3 "${URL}/status" 2>/dev/null || true)
+    STATUS_CODE="${STATUS_CODE:-000}"
     HEALTH=$(curl -sf --connect-timeout 3 "${URL}/-/healthy" 2>/dev/null || echo "")
     READY=$(curl -sf --connect-timeout 3 "${URL}/-/ready" 2>/dev/null || echo "")
     echo "  SP $i (localhost:$PORT): status_code=$STATUS_CODE health=${HEALTH:-N/A} ready=${READY:-N/A}"
@@ -39,9 +47,8 @@ else
   NUM_SPS=$(echo "$SP_JSON" | jq '.sps | length // 0' 2>/dev/null || echo "0")
 
   if [ "$NUM_SPS" -le 0 ]; then
-    echo "  No SPs registered"
-    echo "PASS: SP gateway test skipped (no SPs)"
-    exit 0
+    echo "FAIL: no SPs registered on chain"
+    exit 1
   fi
 
   for i in $(seq 0 $((NUM_SPS - 1))); do
@@ -52,7 +59,8 @@ else
     CHECKED=$((CHECKED + 1))
 
     # Check base endpoint
-    STATUS_CODE=$(curl -sf -o /dev/null -w "%{http_code}" --connect-timeout 5 "${ENDPOINT}" 2>/dev/null || echo "000")
+    STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 "${ENDPOINT}" 2>/dev/null || true)
+    STATUS_CODE="${STATUS_CODE:-000}"
 
     # Check health endpoints
     HEALTH=$(curl -sf --connect-timeout 5 "${ENDPOINT}/-/healthy" 2>/dev/null || echo "")
@@ -64,16 +72,14 @@ else
 fi
 
 if [ "$CHECKED" -eq 0 ]; then
-  echo "  No SP endpoints to check"
-  echo "PASS: SP gateway test skipped"
-  exit 0
+  echo "FAIL: no SP endpoints to check"
+  exit 1
 fi
 
 echo "  Checked: $CHECKED, Reachable: $PASSED, Unreachable: $FAILED"
 
-if [ "$PASSED" -gt 0 ]; then
-  echo "PASS: $PASSED/$CHECKED SP gateway(s) reachable"
-else
-  echo "FAIL: No SP gateways reachable"
+if [ "$FAILED" -gt 0 ]; then
+  echo "FAIL: $FAILED/$CHECKED SP gateway(s) unreachable"
   exit 1
 fi
+echo "PASS: $PASSED/$CHECKED SP gateway(s) reachable"

--- a/tests/test_sp_params.sh
+++ b/tests/test_sp_params.sh
@@ -14,9 +14,8 @@ echo "Testing SP module parameters..."
 # Query SP params
 SP_PARAMS=$(exec_mocad query sp params --node "$TM_RPC" --output json 2>/dev/null || echo "")
 if [ -z "$SP_PARAMS" ] || [ "$SP_PARAMS" = "{}" ]; then
-  echo "  WARN: Cannot query SP params"
-  echo "PASS: SP params query attempted"
-  exit 0
+  echo "  FAIL: cannot query SP params"
+  exit 1
 fi
 
 DEPOSIT_DENOM=$(echo "$SP_PARAMS" | jq -r '.params.deposit_denom // empty' 2>/dev/null)
@@ -24,34 +23,56 @@ MIN_DEPOSIT=$(echo "$SP_PARAMS" | jq -r '.params.min_deposit // empty' 2>/dev/nu
 
 echo "  deposit_denom: $DEPOSIT_DENOM"
 echo "  min_deposit: $MIN_DEPOSIT"
+if [ -z "$DEPOSIT_DENOM" ] || [ -z "$MIN_DEPOSIT" ]; then
+  echo "  FAIL: sp params missing expected fields"
+  exit 1
+fi
 
 # Query storage params
 STORAGE_PARAMS=$(exec_mocad query storage params --node "$TM_RPC" --output json 2>/dev/null || echo "")
-if [ -n "$STORAGE_PARAMS" ] && [ "$STORAGE_PARAMS" != "{}" ]; then
-  MAX_SEGMENT_SIZE=$(echo "$STORAGE_PARAMS" | jq -r '.params.max_segment_size // empty' 2>/dev/null)
-  REDUNDANT_DATA=$(echo "$STORAGE_PARAMS" | jq -r '.params.redundant_data_chunk_num // empty' 2>/dev/null)
-  REDUNDANT_PARITY=$(echo "$STORAGE_PARAMS" | jq -r '.params.redundant_parity_chunk_num // empty' 2>/dev/null)
+if [ -z "$STORAGE_PARAMS" ] || [ "$STORAGE_PARAMS" = "{}" ]; then
+  echo "  FAIL: cannot query storage params"
+  exit 1
+fi
+MAX_SEGMENT_SIZE=$(echo "$STORAGE_PARAMS" | jq -r '.params.versioned_params.max_segment_size // empty' 2>/dev/null)
+REDUNDANT_DATA=$(echo "$STORAGE_PARAMS" | jq -r '.params.versioned_params.redundant_data_chunk_num // empty' 2>/dev/null)
+REDUNDANT_PARITY=$(echo "$STORAGE_PARAMS" | jq -r '.params.versioned_params.redundant_parity_chunk_num // empty' 2>/dev/null)
 
-  echo "  max_segment_size: $MAX_SEGMENT_SIZE"
-  echo "  redundant_data_chunks: $REDUNDANT_DATA"
-  echo "  redundant_parity_chunks: $REDUNDANT_PARITY"
+echo "  max_segment_size: $MAX_SEGMENT_SIZE"
+echo "  redundant_data_chunks: $REDUNDANT_DATA"
+echo "  redundant_parity_chunks: $REDUNDANT_PARITY"
+if [ -z "$MAX_SEGMENT_SIZE" ] || [ -z "$REDUNDANT_DATA" ] || [ -z "$REDUNDANT_PARITY" ]; then
+  echo "  FAIL: storage versioned params missing expected fields"
+  exit 1
 fi
 
 # Query payment params
 PAYMENT_PARAMS=$(exec_mocad query payment params --node "$TM_RPC" --output json 2>/dev/null || echo "")
-if [ -n "$PAYMENT_PARAMS" ] && [ "$PAYMENT_PARAMS" != "{}" ]; then
-  RESERVE_TIME=$(echo "$PAYMENT_PARAMS" | jq -r '.params.reserve_time // empty' 2>/dev/null)
-  FORCED_SETTLE=$(echo "$PAYMENT_PARAMS" | jq -r '.params.forced_settle_time // empty' 2>/dev/null)
+if [ -z "$PAYMENT_PARAMS" ] || [ "$PAYMENT_PARAMS" = "{}" ]; then
+  echo "  FAIL: cannot query payment params"
+  exit 1
+fi
+RESERVE_TIME=$(echo "$PAYMENT_PARAMS" | jq -r '.params.versioned_params.reserve_time // empty' 2>/dev/null)
+FORCED_SETTLE=$(echo "$PAYMENT_PARAMS" | jq -r '.params.forced_settle_time // empty' 2>/dev/null)
 
-  echo "  payment reserve_time: $RESERVE_TIME"
-  echo "  payment forced_settle_time: $FORCED_SETTLE"
+echo "  payment reserve_time: $RESERVE_TIME"
+echo "  payment forced_settle_time: $FORCED_SETTLE"
+if [ -z "$RESERVE_TIME" ] || [ -z "$FORCED_SETTLE" ]; then
+  echo "  FAIL: payment params missing expected fields"
+  exit 1
 fi
 
 # Query virtualgroup params
 VG_PARAMS=$(exec_mocad query virtualgroup params --node "$TM_RPC" --output json 2>/dev/null || echo "")
-if [ -n "$VG_PARAMS" ] && [ "$VG_PARAMS" != "{}" ]; then
-  GVG_STAKING=$(echo "$VG_PARAMS" | jq -r '.params.gvg_staking_per_bytes // empty' 2>/dev/null)
-  echo "  vg gvg_staking_per_bytes: $GVG_STAKING"
+if [ -z "$VG_PARAMS" ] || [ "$VG_PARAMS" = "{}" ]; then
+  echo "  FAIL: cannot query virtualgroup params"
+  exit 1
+fi
+GVG_STAKING=$(echo "$VG_PARAMS" | jq -r '.params.gvg_staking_per_bytes // empty' 2>/dev/null)
+echo "  vg gvg_staking_per_bytes: $GVG_STAKING"
+if [ -z "$GVG_STAKING" ]; then
+  echo "  FAIL: virtualgroup params missing gvg_staking_per_bytes"
+  exit 1
 fi
 
 echo "PASS: SP/storage/payment/virtualgroup parameters queried"

--- a/tests/test_sp_registration.sh
+++ b/tests/test_sp_registration.sh
@@ -20,9 +20,8 @@ NUM_SPS=$(echo "$SP_JSON" | jq '.sps | length // 0' 2>/dev/null || echo "0")
 echo "  Registered SPs on chain: $NUM_SPS"
 
 if [ "$NUM_SPS" -le 0 ]; then
-  echo "  WARN: No SPs registered on chain (SP gentx may not be supported in this version)"
-  echo "PASS: SP registration query works (0 SPs — expected if spgentx not available)"
-  exit 0
+  echo "  FAIL: no SPs registered on chain"
+  exit 1
 fi
 
 # Check each SP's status

--- a/tests/test_sp_tools.sh
+++ b/tests/test_sp_tools.sh
@@ -35,12 +35,12 @@ echo "Testing sp-tools (moca-cmd)..."
 print_test_section "sp ls"
 OUT="$(exec_moca_cmd sp ls 2>/dev/null || true)"
 if [ -z "$OUT" ]; then
-  echo "WARN: sp ls empty"
-  exit 0
+  echo "FAIL: sp ls returned no output"
+  exit 1
 fi
 if ! echo "$OUT" | grep -qiE "operator|IN_SERVICE|storage"; then
-  echo "WARN: sp ls format unexpected"
-  exit 0
+  echo "FAIL: sp ls format unexpected"
+  exit 1
 fi
 echo "$OUT" | head -25
 
@@ -49,25 +49,23 @@ if [ -z "$EP" ]; then
   EP=$(echo "$OUT" | grep -oE 'https?://[^[:space:]]+' | head -1 || true)
 fi
 if [ -z "$EP" ]; then
-  echo "WARN: could not resolve SP endpoint"
-  echo "PASS: sp ls only"
-  exit 0
+  echo "FAIL: could not resolve any SP endpoint from sp ls"
+  exit 1
 fi
 
 print_test_section "sp head"
 H="$(exec_moca_cmd sp head "$EP" 2>/dev/null || true)"
 if ! echo "$H" | grep -qiE "operator|endpoint|SP info|STATUS"; then
-  echo "WARN: sp head output unexpected"
-else
-  echo "$H" | head -20
+  echo "FAIL: sp head output unexpected"
+  exit 1
 fi
+echo "$H" | head -20
 
 print_test_section "sp get-price"
 P="$(exec_moca_cmd sp get-price "$EP" 2>/dev/null || true)"
-if echo "$P" | grep -qiE "quota|price|bucket"; then
-  echo "$P" | head -25
-  echo "PASS: sp ls / head / get-price"
-else
-  echo "WARN: sp get-price incomplete"
-  exit 0
+if ! echo "$P" | grep -qiE "quota|price|bucket"; then
+  echo "FAIL: sp get-price output unexpected"
+  exit 1
 fi
+echo "$P" | head -25
+echo "PASS: sp ls / head / get-price"

--- a/tests/test_storage_bucket.sh
+++ b/tests/test_storage_bucket.sh
@@ -100,9 +100,8 @@ run_moca_cmd_bucket_full() {
   local out
   out=$(exec_moca_cmd_signed bucket create --tags="$tags" --primarySP "$PRIMARY_SP" "$bucket_url" || true)
   if ! echo "$out" | grep -q "make_bucket:\|$bucket_name"; then
-    echo "  WARN: create output unexpected: $(echo "$out" | head -3)"
-    trap - EXIT
-    exit 0
+    echo "  FAIL: bucket create output unexpected: $(echo "$out" | head -3)"
+    exit 1
   fi
   wait_for_tx 5
 

--- a/tests/test_storage_group.sh
+++ b/tests/test_storage_group.sh
@@ -132,9 +132,8 @@ run_moca_cmd_group_full() {
   local out
   out=$(exec_moca_cmd_signed group create --tags="$tags" "$group_name" || true)
   if ! echo "$out" | grep -q "make_group:\|$group_name"; then
-    echo "  WARN: create group output unexpected"
-    trap - EXIT
-    exit 0
+    echo "  FAIL: group create output unexpected: $(echo "$out" | head -3)"
+    exit 1
   fi
   wait_for_tx 3
 

--- a/tests/test_storage_object.sh
+++ b/tests/test_storage_object.sh
@@ -91,9 +91,8 @@ run_moca_cmd_object_full() {
   local out
   out=$(moca_cmd_tx bucket create --primarySP "$PRIMARY_SP" --tags="$tags" "$bucket_url" || true)
   if ! echo "$out" | grep -q "make_bucket:\|$bucket_name"; then
-    echo "WARN: bucket create output unexpected"
-    trap - EXIT
-    exit 0
+    echo "FAIL: bucket create output unexpected: $(echo "$out" | head -3)"
+    exit 1
   fi
 
   print_test_section "Step 2: put object (blocks until SEALED)"
@@ -111,12 +110,12 @@ run_moca_cmd_object_full() {
   print_test_section "Step 3: object head"
   out=$(exec_moca_cmd object head "$object_path" || true)
   if ! echo "$out" | grep -q "object_name:\"$object_name\""; then
-    echo "WARN: object head missing object name"
-    trap - EXIT
-    exit 0
+    echo "FAIL: object head missing object name"
+    exit 1
   fi
   if ! echo "$out" | grep -q "bucket_name:\"$bucket_name\""; then
-    echo "WARN: object head missing bucket name"
+    echo "FAIL: object head missing bucket name"
+    exit 1
   fi
   print_success "object head fields present"
 

--- a/tests/test_virtualgroup.sh
+++ b/tests/test_virtualgroup.sh
@@ -17,9 +17,8 @@ VG_PARAMS=$(exec_mocad query virtualgroup params \
   --node "$TM_RPC" --output json 2>/dev/null || echo "")
 
 if [ -z "$VG_PARAMS" ] || [ "$VG_PARAMS" = "{}" ]; then
-  echo "  WARN: Virtualgroup module not available"
-  echo "PASS: Virtualgroup query attempted"
-  exit 0
+  echo "  FAIL: cannot query virtualgroup params"
+  exit 1
 fi
 
 GVG_STAKING=$(echo "$VG_PARAMS" | jq -r '.params.gvg_staking_per_bytes // empty' 2>/dev/null)
@@ -32,9 +31,8 @@ SP_JSON=$(exec_mocad query sp storage-providers --node "$TM_RPC" --output json 2
 NUM_SPS=$(echo "$SP_JSON" | jq '.sps | length // 0' 2>/dev/null || echo "0")
 
 if [ "$NUM_SPS" -le 0 ]; then
-  echo "  No SPs registered — skipping GVG queries"
-  echo "PASS: Virtualgroup params queried"
-  exit 0
+  echo "  FAIL: no SPs registered — GVG queries have nothing to verify"
+  exit 1
 fi
 
 # Query global virtual group families


### PR DESCRIPTION
## Why

CI was green while EVM contract deployment was broken and had never once succeeded, and several other tests could pass with the feature under test dead. Two commits:

## Commit 1 — the failure→PASS relabelling pattern (4 tests)

`test_evm_erc20.sh` converted every failure into a pass (`WARN: ... failed` → `PASS: ... attempted` → `exit 0`). The 0.09s runtime was the tell. Root causes found while making it strict:

1. **cast arg order**: `cast send --create <CODE> [SIG] [ARGS]` parses everything after the bytecode as constructor args, so `--private-key` after `--create` errors instantly. The deploy never reached the chain.
2. **Broken bytecode**: the embedded bytecode was hand-truncated mid-metadata; once deployable, every `set()` reverted with `invalid jump destination`. Replaced with a complete deterministic build (solc 0.8.26, optimizer 200, `cbor_metadata=false`, `bytecode_hash=none`; source in the test comment).

Also fixed in commit 1: **test_payment** (creation failures relabelled PASS; deposit/withdraw balances printed but never asserted — now must increase/decrease), **test_sp_params** (query-failure→PASS; stale jq paths under `versioned_params` printed empty fields forever), **test_virtualgroup** (params-failure and 0-SPs soft-passes).

## Commit 2 — the wider soft-pass family (9 tests)

A second independent sweep showed the family was broader than the literal pattern:

- **test_sp_gateway** could green a fully dead stack three ways: `curl -w` prints `000` itself on connect failure, so the `||`-appended fallback made dead gateways read `000000` ≠ `000` and count as *reachable* (a red rolling-PR run shows `Reachable: 6` while every SP crash-looped); the loop was hardcoded to sp-0..5 of a 9-SP topology; and 1 reachable gateway out of N passed the test. Now every sp-N container must be running and reachable. **Verified both directions on a live stack**: stopping sp-8 → `FAIL: 1/9`, restoring → `PASS: 9/9`.
- **smoke_sp_status** queried REST routes that never existed on this chain (greenfield leftovers) and exited 0 on failure — dead since day one. Now queries the real `/moca/storage_providers` route and fails on unreachable/empty.
- **test_evm_transfer**: balance-unchanged after a mined transfer was a WARN→exit 0.
- **storage bucket/object/group**: cmd-path create failures exited 0 silently (cleanup traps now stay armed on failure).
- **test_sp_registration** (0 SPs→PASS), **test_sp_tools** (empty/unparseable output→PASS), **test_sp_diagnose** (no SP visibility→PASS).

Environment-precondition SKIPs (mainnet guard, non-local, no moca-cmd) are untouched — STRICT_SKIPS already reds those in CI shards.

## Validation

All 13 changed tests run against a live stack at current main pins — every one passes strictly, including the gateway negative test above. Payment asserted `0 → 1e18 → 5e17`; erc20 does a real deploy → `set(42)` → `get()=42` roundtrip; REST smoke returns 9 SPs.
