### PR TITLE
fix(sp): bind pprof to loopback in SP entrypoint

### DIFF
--- a/docker/entrypoint-sp.sh
+++ b/docker/entrypoint-sp.sh
@@ -152,9 +152,11 @@ sed -i "s|BlsPrivateKey = '.*'|BlsPrivateKey = '${BLS_KEY}'|g" config.toml
 sed -i "s|HTTPAddress = '.*'|HTTPAddress = '0.0.0.0:9033'|g" config.toml
 sed -i "s|DomainName = '.*'|DomainName = '${SP_NAME}:9033'|g" config.toml
 
-# Patch config: Monitor (metrics on 0.0.0.0 for observability)
+# Patch config: Monitor (metrics/probe on 0.0.0.0 for observability; pprof
+# must stay on loopback — moca-sp refuses to start on a routable pprof bind,
+# and nothing maps 9401 to the host anyway)
 sed -i "s|MetricsHTTPAddress = '.*'|MetricsHTTPAddress = '0.0.0.0:9400'|g" config.toml
-sed -i "s|PProfHTTPAddress = '.*'|PProfHTTPAddress = '0.0.0.0:9401'|g" config.toml
+sed -i "s|PProfHTTPAddress = '.*'|PProfHTTPAddress = '127.0.0.1:9401'|g" config.toml
 sed -i "s|ProbeHTTPAddress = '.*'|ProbeHTTPAddress = '0.0.0.0:9402'|g" config.toml
 
 # Patch config: SpDB (User, Passwd, Address, Database)


### PR DESCRIPTION
## Why

The rolling stack PR (#69) fails all three shards at stack boot: moca-sp `b6f54d76` refuses to start when `PProfHTTPAddress` is bound to a routable interface (upstream: "fix(pprof): keep the diagnostic endpoint on the loopback interface", MOCA-926), and the e2e entrypoint bound it to `0.0.0.0:9401` — every SP crash-loops with:

```
pprof address "0.0.0.0:9401" is not a loopback address, bind it to localhost or set DisablePProf
```

## What

One line: pprof moves to `127.0.0.1:9401`. Nothing maps 9401 to the host, so the only consumer is in-container debugging via `docker exec`, which keeps working. Metrics (9400) and the probe server (9402) are not subject to the loopback check and stay on `0.0.0.0` — the host-mapped gateway health asserts from #67 are unaffected.

Checked the rest of the `e4cd1930..b6f54d76` range for e2e impact: the config-rendering change only affects the redacted log path (the entrypoint's sed patches still apply), the signer change doesn't rename config fields, and the remaining commits don't touch anything the stack or tests consume.

## Validation

Stack built at moca-sp `b6f54d76` with this entrypoint: 9/9 SPs healthy (0/9 in the failing CI runs), pprof answers 200 on loopback in-container, strict gateway test passes 9/9 with `healthy=200 ready=200`, sp-config test passes.

After this merges, the rolling bot's SP bump can go green on its next attempt.
