### PR TITLE
test(gateway): assert unauthenticated /status is rejected, not just answered

### DIFF
--- a/tests/test_sp_gateway.sh
+++ b/tests/test_sp_gateway.sh
@@ -44,7 +44,10 @@ if [ "$ENV" = "local" ]; then
     READY_CODE=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 3 "http://localhost:${PROBE}/-/ready" 2>/dev/null || true)
     READY_CODE="${READY_CODE:-000}"
     echo "  SP $i (gw localhost:$PORT probe localhost:$PROBE): status_code=$STATUS_CODE healthy=$HEALTH_CODE ready=$READY_CODE"
-    if [ "$STATUS_CODE" != "000" ] && [ "$HEALTH_CODE" = "200" ] && [ "$READY_CODE" = "200" ]; then
+    # Unauthenticated /status must be rejected: 400 (unsigned request) or 401
+    # (not in StatusAllowedAccounts). 200 means the endpoint is serving anyone
+    # again; 000/5xx means the gater is down.
+    if { [ "$STATUS_CODE" = "400" ] || [ "$STATUS_CODE" = "401" ]; } && [ "$HEALTH_CODE" = "200" ] && [ "$READY_CODE" = "200" ]; then
       PASSED=$((PASSED + 1))
     else
       FAILED=$((FAILED + 1))


### PR DESCRIPTION
## Why

`test_sp_gateway.sh` accepts any HTTP answer on `/status` (`!= 000`). That leaves a blind spot around moca-storage-provider#86 (`/status` behind `Gateway.StatusAllowedAccounts`): a 401 satisfies the current assert, so e2e would neither confirm the endpoint got closed nor catch it reopening — a 200 to an anonymous caller would still count as healthy.

## What

One assertion: unauthenticated `/status` must return **400** (unsigned request — current builds' behavior, seen in every green run) or **401** (rejected by the allowlist, post-#86). `200` → fail (endpoint serving anyone again); `000`/5xx → fail (gater down). Green across the transition in both pin states, and verifies #86's closure direction from the moment it lands.

The signed-operator positive path (allowlisted account gets 200) needs request signing and is out of scope for the anonymous-probe test.

## Validation

Condition truth-table: 400 → PASS, 401 → PASS, 200 → FAIL, 000 → FAIL, 502 → FAIL. The sp shard exercises the live 400 path on the current pin.
