### PR TITLE
chore: update moca and moca-storage-provider to latest mains

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -5,10 +5,10 @@
 components:
   moca:
     repo: mocachain/moca
-    ref: d1a3de51ed2855da0f74e7fc13d7fc6277933181
+    ref: e8f3913f227efc1efb0619a5f8c0f915a3f15a48
   moca-storage-provider:
     repo: mocachain/moca-storage-provider
-    ref: 2fffc3ac2039d16186c149a22c8b66775b9e7bcc
+    ref: 3c8057a7bce257784200ea23cfd42a10392a57d0
   moca-cmd:
     repo: mocachain/moca-cmd
     ref: bbad0b1a51cc450286205fc9a67f2ab6bc1ff9a2


### PR DESCRIPTION
## What

- moca `d1a3de51` → `e8f3913f` (same ref the rolling PR #74 is testing)
- moca-storage-provider `2fffc3ac` → `3c8057a7` (main HEAD)

Bundled manually since the bot advances one component per green run.

## SP range review

Five authorization-scoping commits, no startup gates (unlike the mTLS/pprof waves): peer-address ratelimit keying, delete-keys body bound, read-records owner scoping, policy-listing scoping, and the bucket object listing restriction. The listing change uses the `includePrivate` parameter pattern at the metadata layer, so internal migration callers are unaffected.

## Validation

Full suite against exactly these pins on a clean amd64 box: **27 PASS, 0 FAIL**, including `test_sp_exit` + empty-family blocker (GVG migration healthy), signed `object ls` through the newly authenticated listing endpoint, payment balance asserts, and the strict gateway probes (`healthy=200 ready=200`, `/status` rejection). `test_storage_object_failover` SKIPs on the shared local stack (sp-0 already exited in the same run) — CI's fresh sharded stacks run it.
