### PR TITLE
chore: update known-good stack pointer

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@
 components:
   moca:
     repo: mocachain/moca
-    ref: 62381fbd5a294e3877a8f859150f864847e2c205
+    ref: 129dc6e199b1f392c5e09da9130c089665fbc976
   moca-storage-provider:
     repo: mocachain/moca-storage-provider
     ref: 942ab853012b05369488459e2e06f2d9aba391d3


### PR DESCRIPTION
## Auto-generated rolling PR

Updates stack.yaml with latest tested component refs.
Automatically force-pushed when source repos merge to main.

**Do not manually merge** — advance-pointer workflow handles this on green CI.