### PR TITLE
fix(genesis): shorten challenge deposit-lock window for SP exit tests

### DIFF
--- a/scripts/init-genesis.sh
+++ b/scripts/init-genesis.sh
@@ -62,6 +62,16 @@ jq --arg period "$GOV_VOTING_PERIOD" --arg deposit "$GOV_MIN_DEPOSIT" --arg expe
   .app_state.gov.deposit_params.min_deposit = [{"denom": $denom, "amount": $deposit}]
 ' "$GENESIS" > "$TMPFILE" && mv "$TMPFILE" "$GENESIS"
 
+# Shorten the challenge deposit lock so SP exit completes within the test window.
+# moca holds an exiting SP's deposit until every challenge that can name it has
+# lapsed (challenge_keep_alive_period blocks). The chain auto-raises one challenge
+# per block and the e2e runs no attester, so with the 300-block default the lock
+# outlives the sp-exit tests' wait. Five blocks lets the lock clear a few blocks
+# after GVG migration while keeping auto-challenge active.
+jq '
+  .app_state.challenge.params.challenge_keep_alive_period = "5"
+' "$GENESIS" > "$TMPFILE" && mv "$TMPFILE" "$GENESIS"
+
 # Set block time (consensus params)
 jq --arg bt "$BLOCK_TIME" '
   .consensus.params.block.time_iota_ms = "500"


### PR DESCRIPTION
## Why

The rolling PR (#87) fails `e2e (sp)` and `e2e (flows)` on the moca bump to `aab9161c`, which includes **moca #409** ("resolve the attested provider from the challenge and hold its deposit"). That change holds an exiting SP's deposit in the module account until every challenge that could name it has lapsed — `StorageProviderExitable` now returns `deposit is locked for pending challenges until height N`.

The e2e chain auto-raises **one challenge per block** (`challenge_count_per_block=1`) with the default **`challenge_keep_alive_period=300`**, and runs **no attester**, so a challenge naming the target SP's sealed object locks its deposit for ~300 blocks (~250s) — far longer than the sp-exit tests' wait.

Cascade: `test_sp_exit`'s target can't complete exit → stuck `GRACEFUL_EXITING` → `test_sp_exit_empty_family_blocker`'s initial `sp.exit` is then rejected by the one-concurrent-exit guard. Both red. (The tx reaches a block and reverts with `Status 0` — ante passes, execution refuses — so this is not the new no-chain-id ante from #415.)

This is **intended chain behavior**, not a regression — the deposit must stay locked while a slash is still possible. The e2e just needs the lock to lapse inside the test window.

## Fix

Set `challenge_keep_alive_period = "5"` in the e2e genesis. The deposit lock clears a few blocks after GVG migration (once the SP stores nothing, no new challenge can name it), while auto-challenge stays active. No suite test attests challenges, so nothing else changes.

## Validation

Clean amd64 stack at the exact pins that expose the failure (moca `aab9161c`, moca-storage-provider `c96d759a`), `challenge_keep_alive_period=5` confirmed live on-chain:

- `test_sp_exit`: GVG migrates 1→8, **target SP completes final exit automatically**, object still downloads from the successor with matching sha256 — **PASS**.
- `test_sp_exit_empty_family_blocker`: initial `sp.exit` succeeds (no stuck-SP cascade), complete-exit correctly **blocked by the empty family** (the behavior it guards) — **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7Aij3TFdB1PDQtKkGhBmj