### PR TITLE
ci(1.4): release/1.4 rolling stack + auto-dispatch workflows

### DIFF
--- a/.github/workflows/advance-pointer-1.4.yml
+++ b/.github/workflows/advance-pointer-1.4.yml
@@ -1,0 +1,74 @@
+name: Advance Stack Pointer (1.4)
+
+# Merges the auto/stack-update-1.4 rolling PR once Test Stack (1.4) passes,
+# advancing the known-good pointer for the moca v1.4 release line. Mirrors
+# advance-pointer.yml, scoped to the 1.4 rolling branch.
+
+on:
+  check_suite:
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  ROLLING_BRANCH: auto/stack-update-1.4
+
+jobs:
+  advance:
+    runs-on: ubuntu-latest
+    if: github.event.check_suite.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.E2E_HUB_PAT }}
+
+      - name: Find rolling PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.E2E_HUB_PAT }}
+        run: |
+          PR_NUMBER=$(gh pr list --head "$ROLLING_BRANCH" --json number,mergeable --jq '.[0] | select(.mergeable == "MERGEABLE") | .number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No mergeable 1.4 rolling PR found, skipping."
+            echo "found=false" >> $GITHUB_OUTPUT
+          else
+            echo "Found 1.4 rolling PR #$PR_NUMBER"
+            echo "found=true" >> $GITHUB_OUTPUT
+            echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check all status checks passed
+        if: steps.pr.outputs.found == 'true'
+        id: checks
+        env:
+          GH_TOKEN: ${{ secrets.E2E_HUB_PAT }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.number }}"
+          STATUS=$(gh pr checks "$PR_NUMBER" --json bucket --jq '[.[] | .bucket] | if all(. == "pass") then "pass" else "fail" end')
+          if [ "$STATUS" = "pass" ]; then
+            echo "All checks passed"
+            echo "passed=true" >> $GITHUB_OUTPUT
+          else
+            echo "Not all checks passed, skipping merge"
+            echo "passed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Merge rolling PR
+        if: steps.pr.outputs.found == 'true' && steps.checks.outputs.passed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.E2E_HUB_PAT }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.number }}"
+          echo "Merging 1.4 rolling PR #$PR_NUMBER — advancing release/1.4 known-good pointer"
+          gh pr merge "$PR_NUMBER" --squash --delete-branch
+
+      - name: Notify on failure
+        if: steps.pr.outputs.found == 'true' && steps.checks.outputs.passed == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.E2E_HUB_PAT }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.number }}"
+          PR_URL=$(gh pr view "$PR_NUMBER" --json url --jq '.url')
+          echo "::warning::E2E (1.4) tests failed for rolling PR $PR_URL"

--- a/.github/workflows/test-stack-1.4.yml
+++ b/.github/workflows/test-stack-1.4.yml
@@ -1,0 +1,219 @@
+name: Test Stack (1.4)
+
+# Mirrors test-stack.yml but exercises stack-1.4.yaml — the moca v1.4 release
+# line. Shares every script and Dockerfile with the main flow; only the stack
+# file (and therefore the component refs) differ.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'stack-1.4.yaml'
+      - 'scripts/**'
+      - 'tests/**'
+      - 'docker/**'
+      - 'topology/**'
+      - '.github/workflows/test-stack-1.4.yml'
+
+  workflow_dispatch:
+    inputs:
+      topology:
+        description: 'Topology to test'
+        required: false
+        default: 'default'
+        type: choice
+        options:
+          - default
+          - minimal
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: e2e-test-1.4-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  GHCR_REPO: ghcr.io/${{ github.repository_owner }}/moca-e2e
+  STACK_FILE: stack-1.4.yaml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      moca_sha: ${{ steps.shas.outputs.moca_sha }}
+      sp_sha: ${{ steps.shas.outputs.sp_sha }}
+      cmd_sha: ${{ steps.shas.outputs.cmd_sha }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install tools
+        timeout-minutes: 2
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          sudo apt-get install -y jq
+
+      - name: Make scripts executable
+        run: chmod +x scripts/*.sh
+
+      - name: Clone repos at stack refs
+        timeout-minutes: 5
+        run: ./scripts/clone-repos.sh "$STACK_FILE"
+        env:
+          GH_TOKEN: ${{ secrets.E2E_HUB_PAT }}
+
+      - name: Resolve component SHAs
+        id: shas
+        run: |
+          echo "moca_sha=$(git -C build/moca rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+          echo "sp_sha=$(git -C build/moca-storage-provider rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+          echo "cmd_sha=$(git -C build/moca-cmd rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build and cache images
+        timeout-minutes: 25
+        run: ./scripts/build.sh local
+        env:
+          IMAGE_MODE: cache
+          GH_TOKEN: ${{ secrets.E2E_HUB_PAT }}
+
+  e2e:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    name: e2e (${{ matrix.group }})
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [chain, sp, flows]
+    env:
+      TOPOLOGY: topology/${{ github.event.inputs.topology || 'default' }}.yaml
+      COMPOSE: docker compose -f docker-compose.generated.yml
+      IMAGE_MODE: pull
+      MOCA_SHA: ${{ needs.build.outputs.moca_sha }}
+      SP_SHA: ${{ needs.build.outputs.sp_sha }}
+      CMD_SHA: ${{ needs.build.outputs.cmd_sha }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install tools
+        timeout-minutes: 2
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          sudo apt-get install -y jq
+
+      - name: Install Foundry (cast)
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Make scripts executable
+        run: |
+          chmod +x scripts/*.sh
+          chmod +x tests/*.sh
+
+      - name: Generate docker-compose
+        run: ./scripts/generate-compose.sh "$TOPOLOGY" docker-compose.generated.yml
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Pull prebuilt images
+        timeout-minutes: 5
+        run: ./scripts/build.sh local
+
+      - name: Run genesis init
+        timeout-minutes: 5
+        run: |
+          $COMPOSE up genesis-init 2>&1 | tail -20
+          echo "Genesis init complete"
+
+      - name: Start validators and MySQL
+        timeout-minutes: 3
+        run: |
+          $COMPOSE up -d --no-deps mysql \
+            $($COMPOSE config --services | grep '^validator-')
+
+      - name: Wait for chain
+        timeout-minutes: 10
+        run: ./scripts/wait-for-chain.sh http://localhost:26657 5 540
+
+      - name: Start storage providers
+        timeout-minutes: 2
+        run: |
+          SP_SERVICES=$($COMPOSE config --services | grep '^sp-' | tr '\n' ' ')
+          echo "Starting SPs: $SP_SERVICES"
+          $COMPOSE up -d --no-deps $SP_SERVICES
+
+      - name: Wait for storage providers to be healthy
+        timeout-minutes: 10
+        run: |
+          SP_SERVICES=$($COMPOSE config --services | grep '^sp-')
+          echo "Waiting for SPs to become healthy..."
+          for sp in $SP_SERVICES; do
+            echo "  Waiting for $sp..."
+            timeout 480 bash -c "
+              until [ \"\$(docker inspect --format='{{.State.Health.Status}}' $sp 2>/dev/null)\" = 'healthy' ]; do
+                STATUS=\$(docker inspect --format='{{.State.Health.Status}}' $sp 2>/dev/null || echo 'unknown')
+                echo \"    $sp status: \$STATUS\"
+                sleep 10
+              done
+              echo \"    $sp is healthy\"
+            "
+          done
+          echo "All SPs are healthy"
+          $COMPOSE ps
+
+      - name: Start moca-cmd sidecar
+        timeout-minutes: 2
+        run: |
+          $COMPOSE up -d --no-deps moca-cmd
+          for i in $(seq 1 30); do
+            if docker exec moca-cmd test -f /root/.moca-cmd/account/defaultKey 2>/dev/null; then
+              echo "moca-cmd ready: $(docker exec moca-cmd cat /root/.moca-cmd/account/defaultKey)"
+              break
+            fi
+            [ "$i" -eq 30 ] && { echo "moca-cmd failed to bootstrap"; docker logs moca-cmd; exit 1; }
+            sleep 2
+          done
+
+      - name: Run E2E tests
+        timeout-minutes: 20
+        env:
+          TEST_GROUP: ${{ matrix.group }}
+          STRICT_SKIPS: "1"
+        run: ./scripts/run-suite.sh local config/local.yaml
+
+      - name: Collect logs
+        if: always()
+        timeout-minutes: 3
+        run: |
+          mkdir -p test-results/logs
+          for svc in $($COMPOSE config --services 2>/dev/null); do
+            $COMPOSE logs "$svc" > "test-results/logs/${svc}.log" 2>&1 || true
+          done
+          $COMPOSE logs > test-results/logs/all.log 2>&1 || true
+          $COMPOSE ps -a > test-results/logs/containers.txt 2>&1 || true
+          echo "=== Critical errors ===" | tee test-results/logs/errors-summary.txt
+          grep -ihE "ERR|panic|CONSENSUS FAILURE|validator set is empty|invalid chain-id|fatal" \
+            test-results/logs/*.log 2>/dev/null \
+            | grep -v "log_level" \
+            | sort -u \
+            | tee -a test-results/logs/errors-summary.txt || echo "No critical errors found"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: test-results-1.4-${{ matrix.group }}
+          path: test-results/
+          retention-days: 7
+
+      - name: Teardown
+        if: always()
+        timeout-minutes: 3
+        run: $COMPOSE down -v --remove-orphans --timeout 30 || true

--- a/.github/workflows/update-stack-1.4.yml
+++ b/.github/workflows/update-stack-1.4.yml
@@ -1,0 +1,120 @@
+name: Update Stack (1.4)
+
+# Rolling updater for the moca v1.4 release line. Refreshes stack-1.4.yaml's
+# rolling components (moca, moca-storage-provider) to their release/1.4.x HEADs
+# and opens/updates the auto/stack-update-1.4 PR. Test Stack (1.4) runs on that
+# PR; Advance Stack Pointer (1.4) merges it on green.
+#
+# moca-cmd, moca-juno and the SDK forks stay pinned to the exact refs that
+# moca-storage-provider's release/1.4.x go.mod resolves to — they change only
+# when that go.mod does, via a manual edit to stack-1.4.yaml.
+
+on:
+  # Poll release/1.4.x every 20 minutes (self-contained; no source-repo hook
+  # required). Runs this whole week while the 1.4 line is under active debugging.
+  schedule:
+    - cron: '*/20 * * * *'
+  # Also accept an explicit push notification from moca / moca-storage-provider
+  # release/1.4.x, if their notify-e2e workflow is extended to send it.
+  repository_dispatch:
+    types: [repo-updated-1.4]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: stack-update-1.4
+  cancel-in-progress: false
+
+env:
+  ROLLING_BRANCH: auto/stack-update-1.4
+  STACK_FILE: stack-1.4.yaml
+  RELEASE_BRANCH: release/1.4.x
+  # Components that track the release branch and roll forward automatically.
+  ROLLING_COMPONENTS: "moca moca-storage-provider"
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: main
+          token: ${{ secrets.E2E_HUB_PAT }}
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Refresh rolling components to release/1.4.x HEAD
+        env:
+          GH_TOKEN: ${{ secrets.E2E_HUB_PAT }}
+        run: |
+          : > /tmp/stack-changes
+          for COMPONENT in $ROLLING_COMPONENTS; do
+            if [ "$(yq ".components.${COMPONENT}" "$STACK_FILE")" = "null" ]; then
+              echo "Warning: ${COMPONENT} not in ${STACK_FILE}, skipping."
+              continue
+            fi
+            REF=$(yq ".components.${COMPONENT}.ref" "$STACK_FILE")
+            CREPO=$(yq ".components.${COMPONENT}.repo" "$STACK_FILE")
+            HEAD=$(gh api "repos/${CREPO}/commits/${RELEASE_BRANCH}" --jq .sha || true)
+            if ! echo "$HEAD" | grep -qE '^[0-9a-f]{40}$'; then
+              echo "Warning: cannot resolve ${RELEASE_BRANCH} HEAD for ${CREPO}, keeping ${REF}"
+              continue
+            fi
+            if [ "$HEAD" != "$REF" ]; then
+              yq -i ".components.${COMPONENT}.ref = \"${HEAD}\"" "$STACK_FILE"
+              echo "${COMPONENT}: ${REF} -> ${HEAD}" >> /tmp/stack-changes
+            fi
+          done
+          echo "=== Changes ==="
+          cat /tmp/stack-changes || true
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet "$STACK_FILE"; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Force-push rolling branch
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$ROLLING_BRANCH"
+          git add "$STACK_FILE"
+          git commit -m "chore: update 1.4 stack pointer to release/1.4.x HEAD" \
+            -m "$(cat /tmp/stack-changes)"
+          git push --force origin "$ROLLING_BRANCH"
+
+      - name: Create or update PR
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.E2E_HUB_PAT }}
+        run: |
+          EXISTING_PR=$(gh pr list --head "$ROLLING_BRANCH" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING_PR" ]; then
+            echo "Rolling PR #$EXISTING_PR updated via force-push."
+          else
+            gh pr create \
+              --title "chore: update known-good stack pointer (1.4)" \
+              --body "$(cat <<'EOF'
+          ## Auto-generated rolling PR — release/1.4 line
+
+          Updates `stack-1.4.yaml` with the latest release/1.4.x refs of moca and
+          moca-storage-provider. moca-cmd, moca-juno and the SDK forks stay pinned
+          to the refs moca-storage-provider's release/1.4.x go.mod resolves to.
+
+          **Do not manually merge** — Advance Stack Pointer (1.4) handles this on green CI.
+          EOF
+            )" \
+              --head "$ROLLING_BRANCH" \
+              --base main
+          fi

--- a/stack-1.4.yaml
+++ b/stack-1.4.yaml
@@ -1,0 +1,37 @@
+# Known-good stack pointer — release/1.4 line
+# Each entry represents a tested, working combination of commits for the moca
+# v1.4 release line. Only updated automatically when E2E tests pass.
+#
+# moca and moca-storage-provider track their release/1.4.x branches (the rolling
+# components). moca-cmd, moca-juno and the SDK forks are pinned to the exact refs
+# that moca-storage-provider's release/1.4.x go.mod resolves to, so the CLI and
+# indexer stay proto-compatible with the 1.4 chain. Only moca, moca-storage-
+# provider and moca-cmd are built into images; juno and the forks are recorded
+# for provenance (juno compiles into moca-sp via go.mod; the SDK forks are pulled
+# from each repo's own go.mod, not wired in from here).
+
+components:
+  moca:
+    repo: mocachain/moca
+    ref: 3097f6e8aa2aa44021f37d2c1cbcf0c84bd796ab
+  moca-storage-provider:
+    repo: mocachain/moca-storage-provider
+    ref: 711d39058d0fa0d328d2e7df4c43f3b923e88dd3
+  moca-cmd:
+    repo: mocachain/moca-cmd
+    ref: 806a8738ff54f8723456a24b396bedf17812953c
+  moca-juno:
+    repo: mocachain/moca-juno
+    ref: b1f1e6fd4e65c64fd59d8a7fd1e81f1b9e1b16a4
+  moca-common:
+    repo: mocachain/moca-common
+    ref: de7b6add70a3c9aa216dda6f3e612da28b23ae40
+  moca-go-sdk:
+    repo: mocachain/moca-go-sdk
+    ref: d578d73e25990488edd922732d6dfdc12d02c8b4
+  moca-cosmos-sdk:
+    repo: mocachain/moca-cosmos-sdk
+    ref: 0edb2e9d600f5e6c470cff1ddb08f2060f90054e
+  moca-cometbft:
+    repo: mocachain/moca-cometbft
+    ref: 83994359d4432dfdb729414a5c07359e5589e82f


### PR DESCRIPTION
## What

A parallel rolling flow for the **moca v1.4 release line**, alongside the existing main-tracking one. Shares every script, Dockerfile and test with the main flow, so all the stability work already on main (mTLS provisioning, pprof loopback, gateway probe asserts, payment privkey path, challenge deposit-lock window) applies unchanged.

- **stack-1.4.yaml** — moca and moca-storage-provider track `release/1.4.x`; moca-cmd, moca-juno and the SDK forks are pinned to the exact refs that **moca-storage-provider's release/1.4.x go.mod** resolves to (per your steer): moca-cmd `v1.2.0-rc1`, juno `b1f1e6fd`, go-sdk `d578d73e`, common `de7b6add`, cosmos-sdk `0edb2e9d`, cometbft `83994359`. Only moca/moca-sp/moca-cmd are built into images (juno compiles into moca-sp via go.mod; the forks are provenance — nothing wires them into the mocad build).
- **test-stack-1.4.yml** — builds + shards the e2e against stack-1.4.yaml (chain/sp/flows).
- **update-stack-1.4.yml** — refreshes moca + moca-sp to `release/1.4.x` HEAD every 20 min (self-contained, no source-repo hook needed) or on a `repo-updated-1.4` dispatch; maintains the `auto/stack-update-1.4` PR.
- **advance-pointer-1.4.yml** — merges that PR on green.

## Why this shape

Full auto-dispatch needs the three workflows on `main`. This PR carries them plus the validated stack, and runs **Test Stack (1.4)** on itself now — so it doubles as the **active rolling PR for the week**. Merging it flips on the schedule + advance-pointer machinery; until then it stays open and green-tracked (nothing auto-merges it — advance-pointer keys off `auto/stack-update`, not this branch).

## Validation

Clean amd64 box at these exact refs: all five images build, genesis inits, chain produces blocks (**EVM chain-id 0x141f = 5151**), **9 SPs healthy**, and **14/14** representative tests pass — chain, EVM deploy+interact, moca-cmd storage (bucket/object/group/payment), SP registration/gateway, virtualgroup, staking, and the full **SP-exit** workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7Aij3TFdB1PDQtKkGhBmj