### PR TITLE
fix(genesis): disable auto-challenge so SP exit can complete

### DIFF
--- a/scripts/init-genesis.sh
+++ b/scripts/init-genesis.sh
@@ -62,13 +62,20 @@ jq --arg period "$GOV_VOTING_PERIOD" --arg deposit "$GOV_MIN_DEPOSIT" --arg expe
   .app_state.gov.deposit_params.min_deposit = [{"denom": $denom, "amount": $deposit}]
 ' "$GENESIS" > "$TMPFILE" && mv "$TMPFILE" "$GENESIS"
 
-# Shorten the challenge deposit lock so SP exit completes within the test window.
-# moca holds an exiting SP's deposit until every challenge that can name it has
-# lapsed (challenge_keep_alive_period blocks). The chain auto-raises one challenge
-# per block and the e2e runs no attester, so with the 300-block default the lock
-# outlives the sp-exit tests' wait. Five blocks lets the lock clear a few blocks
-# after GVG migration while keeping auto-challenge active.
+# Stop auto-raising challenges so an exiting SP can complete its exit.
+# moca (#409) holds an exiting SP's deposit until every open challenge that
+# names it has lapsed (challenge_keep_alive_period blocks). challenge_count_per_
+# block auto-raises challenges every block with no attester to settle them, and
+# SetDepositLockUntil is a forward-only watermark: while the SP still holds any
+# object (it is a secondary in the auxiliary bucket right up to swap-out), each
+# block re-arms the lock to height+keep_alive, so the window never lapses and
+# sp.complete.exit reverts. Shortening keep_alive alone (from #88) does not help
+# because the lock is continuously renewed. No suite test exercises auto-raised
+# challenges, so disable them; test_challenge* can re-enable locally if added.
+# keep_alive stays at a small non-zero value (the module rejects zero) in case a
+# future test raises a challenge by hand.
 jq '
+  .app_state.challenge.params.challenge_count_per_block = "0" |
   .app_state.challenge.params.challenge_keep_alive_period = "5"
 ' "$GENESIS" > "$TMPFILE" && mv "$TMPFILE" "$GENESIS"
 


### PR DESCRIPTION
## Why

The rolling PR (#87) still fails `e2e (sp)` and `e2e (flows)` even with #88's `challenge_keep_alive_period=5`. `sp.complete.exit` reverts on-chain (`Status 0`, full 2.5M gas) at block ~88, the SP stays `GRACEFUL_EXITING`, and both `test_sp_exit` and `test_sp_exit_empty_family_blocker` fail (the blocker only because the first test leaves an SP stuck exiting — one root cause).

## Root cause (my analysis, confirmed against #409's code + the CI log)

moca #409 holds an exiting SP's deposit until every open challenge that names it has lapsed (`StorageProviderExitable` → `deposit is locked for pending challenges until height N`), and `SetDepositLockUntil` is a **forward-only watermark**. With `challenge_count_per_block=1` and **no attester**, a challenge is auto-raised every block. The target SP holds objects **both as primary** (its own bucket) **and as secondary** (the auxiliary bucket) right up to swap-out, so it keeps getting named and the lock re-arms to `height+keep_alive` every block. The 5-block window never gets a clear run, so complete-exit reverts.

Shortening the window (#88) can't fix a lock that's continuously renewed — the renewal has to stop. That also explains why #88 passed on one SP build and failed on another: the manager's auto-complete timing (changed by moca-sp `c96d759a→dae3c7bc`, all manager fixes) raced the renewing lock.

## Fix

`challenge_count_per_block = 0` in the e2e genesis — nothing auto-raises, so no deposit lock is ever set and exit is deterministic regardless of manager timing. No suite test exercises auto-raised challenges (`test_challenge*` can re-enable locally if added). `keep_alive` stays `5` (the module rejects `0`) as belt-and-braces for a hand-raised challenge.

## Validation

At the **exact pins CI fails on** (moca `aab9161c`, moca-storage-provider `dae3c7bc`): `challenge_count_per_block=0` confirmed live, and **both** `test_sp_exit` (auto complete-exit succeeds) and `test_sp_exit_empty_family_blocker` (complete-exit correctly blocked by the *empty family*, not the lock) pass. Unlike #88, this was validated at the CI-failing refs, and the fix is timing-independent.

> **Chain-side note (not this PR):** #409 means any network running auto-challenge with no/slow attester delays SP complete-exit by up to `challenge_keep_alive_period` blocks after swap-out (on devnet/testnet with keep_alive=300, ~250s). Bounded, not permanent, but a real operational consequence worth tracking on the moca side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7Aij3TFdB1PDQtKkGhBmj